### PR TITLE
Require ruby ~> 2.5

### DIFF
--- a/arx.gemspec
+++ b/arx.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
     Gemfile LICENSE CHANGELOG.md README.md Rakefile arx.gemspec
   ]
 
+  spec.required_ruby_version = '~> 2.5'
+
   spec.add_runtime_dependency 'nokogiri', '~> 1.10'
   spec.add_runtime_dependency 'nokogiri-happymapper', '~> 0.8'
 


### PR DESCRIPTION
Specify required ruby version `~> 2.5` in `arx.gemspec`.