### PR TITLE
Flatten provided values in field instance methods

### DIFF
--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -161,6 +161,8 @@ module Arx
       define_method(name) do |*values, exact: true, connective: :and|
         return if values.empty?
 
+        values.flatten!
+
         Validate.values values
         Validate.categories values if name == :category
         Validate.exact exact


### PR DESCRIPTION
Paper instance methods currently don't accept arrays as an argument. Flattening the splat argument allows for the encapsulation of this.