### PR TITLE
[release] 0.2.0 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # 0.2.0
 
+#### Major changes
+
+- Flatten provided values in `Arx::Paper`'s field instance methods (allow an array as the `values` splat parameter). ([#5](https://github.com/eonu/arx/pull/5))
+- Add `Arx.find` and `Arx.get` as aliases for `Arx.search`. ([#6](https://github.com/eonu/arx/pull/6), [#8](https://github.com/eonu/arx/pull/8))
+
+#### Minor changes
+
 - Add `homepage` and `metadata` fields to `arx.gemspec`. ([#1](https://github.com/eonu/arx/pull/1), [#14](https://github.com/eonu/arx/pull/14))
 - Specify required ruby version (`~> 2.5`) in `arx.gemspec`. ([#2](https://github.com/eonu/arx/pull/2))
 - Add badges to `README.md`. ([#3](https://github.com/eonu/arx/pull/3), [#9](https://github.com/eonu/arx/pull/9))
 - Fix documentation for `Arx::Paper`'s field methods `exact` argument. ([#4](https://github.com/eonu/arx/pull/4))
-- Flatten provided values in `Arx::Paper`'s field instance methods (allow an array as the `values` splat parameter). ([#5](https://github.com/eonu/arx/pull/5))
-- Add `Arx.find` and `Arx.get` as aliases for `Arx.search`. ([#6](https://github.com/eonu/arx/pull/6), [#8](https://github.com/eonu/arx/pull/8))
 - Update documentation links in `arx.gemspec` and `README.md`. ([#7](https://github.com/eonu/arx/pull/7))
 - Remove newline from end of `Gemfile`. ([#11](https://github.com/eonu/arx/pull/11))
 - Add ruby-head version to RVM rubies in `.travis.yml`. ([#12](https://github.com/eonu/arx/pull/12))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.2.0
+
+- Add `homepage` and `metadata` fields to `arx.gemspec`. ([#1](https://github.com/eonu/arx/pull/1), [#14](https://github.com/eonu/arx/pull/14))
+- Specify required ruby version (`~> 2.5`) in `arx.gemspec`. ([#2](https://github.com/eonu/arx/pull/2))
+- Add badges to `README.md`. ([#3](https://github.com/eonu/arx/pull/3), [#9](https://github.com/eonu/arx/pull/9))
+- Fix documentation for `Arx::Paper`'s field methods `exact` argument. ([#4](https://github.com/eonu/arx/pull/4))
+- Flatten provided values in `Arx::Paper`'s field instance methods (allow an array as the `values` splat parameter). ([#5](https://github.com/eonu/arx/pull/5))
+- Add `Arx.find` and `Arx.get` as aliases for `Arx.search`. ([#6](https://github.com/eonu/arx/pull/6), [#8](https://github.com/eonu/arx/pull/8))
+- Update documentation links in `arx.gemspec` and `README.md`. ([#7](https://github.com/eonu/arx/pull/7))
+- Remove newline from end of `Gemfile`. ([#11](https://github.com/eonu/arx/pull/11))
+- Add ruby-head version to RVM rubies in `.travis.yml`. ([#12](https://github.com/eonu/arx/pull/12))
+- Remove unnecessary git-ignored files. ([#13](https://github.com/eonu/arx/pull/13), [#10](https://github.com/eonu/arx/pull/10))
+
 # 0.1.0
 
 Initial commit! 🎉

--- a/lib/arx/version.rb
+++ b/lib/arx/version.rb
@@ -5,7 +5,7 @@ module Arx
   # The current version of Arx.
   VERSION = {
     major: 0,
-    minor: 1,
+    minor: 2,
     patch: 0,
     meta: nil
   }.compact.values.join('.').freeze


### PR DESCRIPTION
# Major changes

- Flatten provided values in `Arx::Paper`'s field instance methods (allow an array as the `values` splat parameter). ([#5](https://github.com/eonu/arx/pull/5))
- Add `Arx.find` and `Arx.get` as aliases for `Arx.search`. ([#6](https://github.com/eonu/arx/pull/6), [#8](https://github.com/eonu/arx/pull/8))

# Minor changes

- Add `homepage` and `metadata` fields to `arx.gemspec`. ([#1](https://github.com/eonu/arx/pull/1), [#14](https://github.com/eonu/arx/pull/14))
- Specify required ruby version (`~> 2.5`) in `arx.gemspec`. ([#2](https://github.com/eonu/arx/pull/2))
- Add badges to `README.md`. ([#3](https://github.com/eonu/arx/pull/3), [#9](https://github.com/eonu/arx/pull/9))
- Fix documentation for `Arx::Paper`'s field methods `exact` argument. ([#4](https://github.com/eonu/arx/pull/4))
- Update documentation links in `arx.gemspec` and `README.md`. ([#7](https://github.com/eonu/arx/pull/7))
- Remove newline from end of `Gemfile`. ([#11](https://github.com/eonu/arx/pull/11))
- Add ruby-head version to RVM rubies in `.travis.yml`. ([#12](https://github.com/eonu/arx/pull/12))
- Remove unnecessary git-ignored files. ([#13](https://github.com/eonu/arx/pull/13), [#10](https://github.com/eonu/arx/pull/10))