### PR TITLE
[patch:lib] Remove prefixing search query ampersand (&)

### DIFF
--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -69,7 +69,7 @@ module Arx
       @query = String.new
 
       Validate.sort_by sort_by, permitted: SORT_BY.keys
-      @query << "&#{PARAMS[:sort_by]}=#{SORT_BY[sort_by]}"
+      @query << "#{PARAMS[:sort_by]}=#{SORT_BY[sort_by]}"
 
       Validate.sort_order sort_order, permitted: SORT_ORDER.keys
       @query << "&#{PARAMS[:sort_order]}=#{SORT_ORDER[sort_order]}"


### PR DESCRIPTION
The first field appended to the search query string is `sortBy`. However, this is currently prefixed with an `&`, which is only intended to separate query string fields from each other. This results in an invalid query string.

This PR fixes this issue.