### PR TITLE
[release] 0.3.0 🆕

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.3.0
+
+#### Major changes
+
+- Add documentation, images, installation and usage instructions to `README.md`. ([#22](https://github.com/eonu/arx/pull/22), [#17](https://github.com/eonu/arx/pull/17))
+- Allow prior construction of a search query in `Arx.search`. ([#18](https://github.com/eonu/arx/pull/18))
+- Fix `Arx.search` query object yielding. ([#20](https://github.com/eonu/arx/pull/20))
+
+#### Minor changes
+
+- Remove conditional with `block_given?` in `Arx()` method. ([#16](https://github.com/eonu/arx/pull/16))
+- Remove leading ampersand (&) from search query string. ([#19](https://github.com/eonu/arx/pull/19))
+- Add base paper categories and more aliases. ([#21](https://github.com/eonu/arx/pull/21))
+
 # 0.2.0
 
 #### Major changes

--- a/lib/arx/version.rb
+++ b/lib/arx/version.rb
@@ -5,7 +5,7 @@ module Arx
   # The current version of Arx.
   VERSION = {
     major: 0,
-    minor: 2,
+    minor: 3,
     patch: 0,
     meta: nil
   }.compact.values.join('.').freeze


### PR DESCRIPTION
# Major changes

- Add documentation, images, installation and usage instructions to `README.md`. ([#22](https://github.com/eonu/arx/pull/22), [#17](https://github.com/eonu/arx/pull/17))
- Allow prior construction of a search query in `Arx.search`. ([#18](https://github.com/eonu/arx/pull/18))
- Fix `Arx.search` query object yielding. ([#20](https://github.com/eonu/arx/pull/20))

# Minor changes

- Remove conditional with `block_given?` in `Arx()` method. ([#16](https://github.com/eonu/arx/pull/16))
- Remove leading ampersand (&) from search query string. ([#19](https://github.com/eonu/arx/pull/19))
- Add base paper categories and more aliases. ([#21](https://github.com/eonu/arx/pull/21))