### PR TITLE
[feature:lib] Clean entity introspection and require directives

### DIFF
--- a/lib/arx.rb
+++ b/lib/arx.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
+require 'cgi'
 require 'nokogiri'
 require 'open-uri'
+require 'happymapper'
 require 'arx/version'
+require 'arx/cleaner'
+require 'arx/inspector'
 require 'arx/categories'
-require 'arx/query/query'
+require 'arx/exceptions'
 require 'arx/query/validate'
+require 'arx/query/query'
 require 'arx/entities/author'
 require 'arx/entities/category'
+require 'arx/entities/link'
 require 'arx/entities/paper'
 
 # A Ruby interface for querying academic papers on the arXiv search API.

--- a/lib/arx/entities/author.rb
+++ b/lib/arx/entities/author.rb
@@ -1,11 +1,9 @@
-require 'happymapper'
-require 'arx/cleaner'
-
 module Arx
 
   # Entity/model representing an arXiv paper's author.
   class Author
     include HappyMapper
+    include Inspector
 
     tag 'author'
 
@@ -25,5 +23,7 @@ module Arx
     def affiliations?
       !affiliations.empty?
     end
+
+    inspector :name, :affiliations?, :affiliations
   end
 end

--- a/lib/arx/entities/category.rb
+++ b/lib/arx/entities/category.rb
@@ -1,11 +1,9 @@
-require 'arx/categories'
-require 'arx/cleaner'
-
 module Arx
 
   # Entity/model representing an arXiv paper's category.
   class Category
     include HappyMapper
+    include Inspector
 
     tag 'category'
 
@@ -20,5 +18,7 @@ module Arx
     def full_name
       CATEGORIES[name]
     end
+
+    inspector :name, :full_name
   end
 end

--- a/lib/arx/entities/link.rb
+++ b/lib/arx/entities/link.rb
@@ -1,5 +1,3 @@
-require 'happymapper'
-
 module Arx
 
   # Helper entity/model representing a link on an arXiv paper.

--- a/lib/arx/entities/paper.rb
+++ b/lib/arx/entities/paper.rb
@@ -1,15 +1,9 @@
-require 'happymapper'
-require 'arx/exceptions'
-require 'arx/cleaner'
-require_relative 'author'
-require_relative 'category'
-require_relative 'link'
-
 module Arx
 
   # Entity/model representing an arXiv paper.
   class Paper
     include HappyMapper
+    include Inspector
 
     tag 'entry'
 
@@ -159,5 +153,15 @@ module Arx
         end
       end
     end
+
+    inspector *%i[
+      id url title summary authors
+      primary_category categories
+      publish_date last_updated revision?
+      comment? comment
+      journal? journal
+      pdf? pdf_url
+      doi? doi_url
+    ]
   end
 end

--- a/lib/arx/inspector.rb
+++ b/lib/arx/inspector.rb
@@ -1,0 +1,38 @@
+# Restricts `#inspect` to dump a whitelist of methods on an object.
+# It will always provide `object_id` at a minimum.
+module Inspector
+
+  # Overwrites the object's own inspect method.
+  def inspect
+    pairs = {}
+
+    self.class.inspector_fields.each do |field|
+      pairs[field] = self.send(field).inspect
+    rescue
+    end
+
+    "#<#{self.class.name}:#{self.object_id} #{pairs.map {|k,v| "#{k}=#{v}"}.join(", ")}>"
+  end
+
+  class << self
+    # Returns the +inspected+ instance variable, or sets it if undefined.
+    def inspected
+      @inspected ||= []
+    end
+
+    # Defines helper +inspector_fields+ instance variable & method, and +inspector+ instance method on the target object.
+    # @param [Object] source An arbitrary object (the object that +includes+ the +Inspector+ module).
+    def included(source)
+      inspected << source
+      source.class_eval do
+        def self.inspector(*fields)
+          @inspector_fields = *fields
+        end
+
+        def self.inspector_fields
+          @inspector_fields ||= []
+        end
+      end
+    end
+  end
+end

--- a/lib/arx/inspector.rb
+++ b/lib/arx/inspector.rb
@@ -1,36 +1,39 @@
-# Restricts `#inspect` to dump a whitelist of methods on an object.
-# It will always provide `object_id` at a minimum.
-module Inspector
+module Arx
 
-  # Overwrites the object's own inspect method.
-  def inspect
-    pairs = {}
+  # Restricts +inspect+ to dump a whitelist of methods on an object.
+  # It will always provide `object_id` at a minimum.
+  module Inspector
 
-    self.class.inspector_fields.each do |field|
-      pairs[field] = self.send(field).inspect
-    rescue
+    # Overwrites the object's own inspect method.
+    def inspect
+      pairs = {}
+
+      self.class.inspector_fields.each do |field|
+        pairs[field] = self.send(field).inspect
+      rescue
+      end
+
+      "#<#{self.class.name}:#{self.object_id} #{pairs.map {|k,v| "#{k}=#{v}"}.join(", ")}>"
     end
 
-    "#<#{self.class.name}:#{self.object_id} #{pairs.map {|k,v| "#{k}=#{v}"}.join(", ")}>"
-  end
+    class << self
+      # Returns the +inspected+ instance variable, or sets it if undefined.
+      def inspected
+        @inspected ||= []
+      end
 
-  class << self
-    # Returns the +inspected+ instance variable, or sets it if undefined.
-    def inspected
-      @inspected ||= []
-    end
+      # Defines helper +inspector_fields+ instance variable & method, and +inspector+ instance method on the target object.
+      # @param [Object] source An arbitrary object (the object that +includes+ the +Inspector+ module).
+      def included(source)
+        inspected << source
+        source.class_eval do
+          def self.inspector(*fields)
+            @inspector_fields = *fields
+          end
 
-    # Defines helper +inspector_fields+ instance variable & method, and +inspector+ instance method on the target object.
-    # @param [Object] source An arbitrary object (the object that +includes+ the +Inspector+ module).
-    def included(source)
-      inspected << source
-      source.class_eval do
-        def self.inspector(*fields)
-          @inspector_fields = *fields
-        end
-
-        def self.inspector_fields
-          @inspector_fields ||= []
+          def self.inspector_fields
+            @inspector_fields ||= []
+          end
         end
       end
     end

--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'cgi'
-require_relative 'validate'
-
 module Arx
 
   # Class for generating arXiv search API query strings.

--- a/lib/arx/query/validate.rb
+++ b/lib/arx/query/validate.rb
@@ -1,5 +1,3 @@
-require_relative '../categories'
-
 module Arx
 
   # Validations for arXiv search query fields and identifier schemes.


### PR DESCRIPTION
Read #24.

*Also cleans up require directives, moving them all to `lib/arx.rb`.*