### PR TITLE
[patch:gem] Add email to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Edwin Onuonga
+Copyright (c) 2019 Edwin Onuonga <ed@mail.eonu.net>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Adds [ed@mail.eonu.net](mailto:ed@mail.eonu.net) email address to `LICENSE`.