### PR TITLE
[patch:lib] Split version number from paper identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,18 @@ paper = Arx('1809.09415')
 #=> #<Arx::Paper:0x00007fb657b59bd0>
 
 paper.id
+#=> "1809.09415"
+paper.id(version: true)
 #=> "1809.09415v1"
 paper.url
+#=> "http://arxiv.org/abs/1809.09415"
+paper.url(version: true)
 #=> "http://arxiv.org/abs/1809.09415v1"
+paper.version
+#=> 1
+paper.revision?
+#=> false
+
 paper.title
 #=> "On finitely ambiguous Büchi automata"
 paper.summary
@@ -293,8 +302,6 @@ paper.published_at
 #=> #<DateTime: 2018-09-25T11:40:39+00:00 ((2458387j,42039s,0n),+0s,2299161j)>
 paper.updated_at
 #=> #<DateTime: 2018-09-25T11:40:39+00:00 ((2458387j,42039s,0n),+0s,2299161j)>
-paper.revision?
-#=> false
 
 # Paper's comment
 paper.comment?

--- a/lib/arx.rb
+++ b/lib/arx.rb
@@ -32,7 +32,7 @@ module Arx
   #   1705.01662v1
   #   1412.0135
   #   0706.0001v2
-  NEW_IDENTIFIER_FORMAT = %r"^\d{4}\.\d{4,5}(v\d+)?$"
+  NEW_IDENTIFIER_FORMAT = /^\d{4}\.\d{4,5}(v\d+)?$/
 
   # The legacy arXiv paper identifier scheme (before 1 April 2007).
   #
@@ -40,7 +40,7 @@ module Arx
   # @example
   #   math/0309136v1
   #   cond-mat/0211034
-  OLD_IDENTIFIER_FORMAT = %r"^[a-z]+(\-[a-z]+)?\/\d{7}(v\d+)?$"
+  OLD_IDENTIFIER_FORMAT = /^[a-z]+(\-[a-z]+)?\/\d{7}(v\d+)?$/
 
   class << self
 

--- a/lib/arx/cleaner.rb
+++ b/lib/arx/cleaner.rb
@@ -4,11 +4,44 @@ module Arx
   # @private
   class Cleaner
 
-    # Cleans strings.
-    # @param [String] string Removes newline/return characters and multiple spaces from a string.
-    # @return [String] The cleaned string.
-    def self.clean(string)
-      string.gsub(/\r\n|\r|\n/, ' ').strip.squeeze ' '
+    # arXiv paper URL prefix format
+    URL_PREFIX = /^(https?\:\/\/)?(www.)?arxiv\.org\/abs\//
+
+    class << self
+
+      # Cleans strings.
+      # @param [String] string Removes newline/return characters and multiple spaces from a string.
+      # @return [String] The cleaned string.
+      def clean(string)
+        string.gsub(/\r\n|\r|\n/, ' ').strip.squeeze ' '
+      end
+
+      # Attempt to extract an arXiv identifier from a string such as a URL.
+      #
+      # @param string [String] The string to extract the ID from.
+      # @param version [Boolean] Whether or not to include the paper's version.
+      # @return [String] The extracted ID.
+      def extract_id(string, version: false)
+        raise TypeError.new("Expected `version` to be boolean (TrueClass or FalseClass), got: #{version.class}") unless version == !!version
+        raise TypeError.new("Expected `string` to be a String, got: #{string.class}") unless string.is_a? String
+        string.gsub!(/(#{URL_PREFIX})|(\/$)/, '') if /#{URL_PREFIX}.+\/?$/.match? string
+        raise ArgumentError.new("Couldn't extract arXiv identifier from: #{string}") unless Validate.id? string
+        version ? string : string.sub(/v[0-9]+$/, '')
+      end
+
+      # Attempt to extract a version number from an arXiv identifier.
+      #
+      # @param string [String] The arXiv identifier to extract the version number from.
+      # @return [String] The extracted version number.
+      def extract_version(string)
+        reversed = extract_id(string, version: true).reverse
+
+        if /^[0-9]+v/.match? reversed
+          reversed.partition('v').first.to_i
+        else
+          raise ArgumentError.new("Couldn't extract version number from identifier: #{string}")
+        end
+      end
     end
   end
 end

--- a/lib/arx/entities/paper.rb
+++ b/lib/arx/entities/paper.rb
@@ -13,18 +13,33 @@ module Arx
     # @example
     #   1705.01662v1
     #   cond-mat/0211034
+    # @param version [Boolean] Whether or not to include the paper's version.
     # @return [String] The paper's identifier.
-    def id
-      @id.sub /https?\:\/\/arxiv\.org\/abs\//, ''
+    def id(version: false)
+      Cleaner.extract_id @id, version: version
     end
 
     # The URL of the paper on the arXiv website.
     # @example
     #   http://arxiv.org/abs/1705.01662v1
     #   http://arxiv.org/abs/cond-mat/0211034
+    # @param version [Boolean] Whether or not to include the paper's version.
     # @return [String] The paper's arXiv URL.
-    def url
-      @id
+    def url(version: false)
+      "http://arxiv.org/abs/#{id version: version}"
+    end
+
+    # The version of the paper.
+    # @return [Integer] The paper's version.
+    def version
+      Cleaner.extract_version @id
+    end
+
+    # Whether the paper is a revision or not.
+    # @note A paper is a revision if its {version} is greater than 1.
+    # @return [Boolean]
+    def revision?
+      version > 1
     end
 
     # @!method updated_at
@@ -57,13 +72,6 @@ module Arx
     # The categories of the paper.
     # @return [Array<Category>]
     has_many :categories, Category, tag: 'category'
-
-    # Whether the paper is a revision or not.
-    # @note A paper is a revision if {updated_at} differs from {published_at}.
-    # @return [Boolean]
-    def revision?
-      @published_at != @updated_at
-    end
 
     # @!method summary
     # The summary (or abstract) of the paper.
@@ -152,9 +160,10 @@ module Arx
     end
 
     inspector *%i[
-      id url title summary authors
+      id url version revision?
+      title summary authors
       primary_category categories
-      published_at updated_at revision?
+      published_at updated_at
       comment? comment
       journal? journal
       pdf? pdf_url

--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -66,8 +66,7 @@ module Arx
 
       ids.flatten!
       unless ids.empty?
-        ids.map! {|id| extract_id id}
-        Validate.ids ids
+        ids.map! &Cleaner.method(:extract_id)
         @query << "&#{PARAMS[:id_list]}=#{ids * ','}"
       end
 
@@ -240,19 +239,6 @@ module Arx
     # @return [String] The enquoted string.
     def enquote(string)
       CGI.escape("\"") + string + CGI.escape("\"")
-    end
-
-    # Attempt to extract an ID from an arXiv URL.
-    #
-    # @param url [String] The URL to extract the ID from.
-    # @return [String] The extracted ID if successful, otherwise the original string.
-    def extract_id(url)
-      prefix = %r"^(https?\:\/\/)?(www.)?arxiv\.org\/abs\/"
-      if %r"#{prefix}.*$".match? url
-        url.sub(prefix, '').sub(%r"\/$", '')
-      else
-        url
-      end
     end
   end
 end


### PR DESCRIPTION
- Split version number from paper identifier in `Paper` (add `version` key-word argument to `#id` and `#url`, and add `#version`).
- Change declared regular expression literals from `%r""` to standard `//`.
- Add `Cleaner.extract_id` and `Cleaner.extract_version`.
- Remove `#extract_id` from `Query` and use `Cleaner.extract_id` instead.
- Redefine `Paper#revision?` to use the new `#version` instead of `#updated_at` and`#published_at`.