### PR TITLE
[feature:spec] Implement all tests + Remove version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Although [Scholastica](https://github.com/scholastica) offer a great [Ruby gem](
 
 *Arx is a gem that allows for quick and easy querying of the arXiv search API, without having to worry about manually writing your own search query strings or parse the resulting XML query response to find the data you need.*
 
-## Typical example
+## Example
 
 Suppose we wish to search for:
 

--- a/lib/arx.rb
+++ b/lib/arx.rb
@@ -59,9 +59,15 @@ module Arx
       yield query if block_given?
 
       document = Nokogiri::XML(open ENDPOINT + query.to_s + '&max_results=10000').remove_namespaces!
-      results = Paper.parse(document, single: false).reject {|paper| paper.id.empty?}
-      raise Error::MissingPaper.new(ids.first) if results.empty? && ids.size == 1
-      ids.size == 1 && results.size == 1 ? results.first : results
+      results = Paper.parse(document, single: ids.size == 1)
+
+      if results.is_a? Paper
+        raise Error::MissingPaper.new(ids.first) if results.title.empty?
+      elsif results.is_a? Array
+        results.reject! {|paper| paper.title.empty?}
+      end
+
+      results
     end
 
     alias_method :find, :search

--- a/lib/arx/cleaner.rb
+++ b/lib/arx/cleaner.rb
@@ -22,11 +22,17 @@ module Arx
       # @param version [Boolean] Whether or not to include the paper's version.
       # @return [String] The extracted ID.
       def extract_id(string, version: false)
-        raise TypeError.new("Expected `version` to be boolean (TrueClass or FalseClass), got: #{version.class}") unless version == !!version
-        raise TypeError.new("Expected `string` to be a String, got: #{string.class}") unless string.is_a? String
-        string.gsub!(/(#{URL_PREFIX})|(\/$)/, '') if /#{URL_PREFIX}.+\/?$/.match? string
-        raise ArgumentError.new("Couldn't extract arXiv identifier from: #{string}") unless Validate.id? string
-        version ? string : string.sub(/v[0-9]+$/, '')
+        if version == !!version
+          if string.is_a? String
+            trimmed = /#{URL_PREFIX}.+\/?$/.match?(string) ? string.gsub(/(#{URL_PREFIX})|(\/$)/, '') : string
+            raise ArgumentError.new("Couldn't extract arXiv identifier from: #{string}") unless Validate.id? trimmed
+            version ? trimmed : trimmed.sub(/v[0-9]+$/, '')
+          else
+            raise TypeError.new("Expected `string` to be a String, got: #{string.class}")
+          end
+        else
+          raise TypeError.new("Expected `version` to be boolean (TrueClass or FalseClass), got: #{version.class}")
+        end
       end
 
       # Attempt to extract a version number from an arXiv identifier.

--- a/lib/arx/cleaner.rb
+++ b/lib/arx/cleaner.rb
@@ -43,7 +43,7 @@ module Arx
         reversed = extract_id(string, version: true).reverse
 
         if /^[0-9]+v/.match? reversed
-          reversed.partition('v').first.to_i
+          reversed.partition('v').first.reverse.to_i
         else
           raise ArgumentError.new("Couldn't extract version number from identifier: #{string}")
         end

--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -188,8 +188,9 @@ module Arx
     # @param connective [Symbol] The symbol of the logical connective to add.
     # @return [self]
     def add_connective(connective)
-      return unless search_query?
-      @query << "+#{CONNECTIVES[connective]}" unless ends_with_connective?
+      if search_query?
+        @query << "+#{CONNECTIVES[connective]}" unless ends_with_connective?
+      end
       self
     end
 

--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -199,12 +199,8 @@ module Arx
     # @param subquery [String] The subquery to add.
     def add_subquery(subquery)
       if search_query?
-        if ends_with_connective?
-          @query << "+#{subquery}"
-        else
-          add_connective :and
-          @query << "+#{subquery}"
-        end
+        add_connective :and unless ends_with_connective?
+        @query << "+#{subquery}"
       else
         @query << "&#{PARAMS[:search_query]}=#{subquery}"
       end

--- a/lib/arx/query/validate.rb
+++ b/lib/arx/query/validate.rb
@@ -94,7 +94,9 @@ module Arx
       # @see NEW_IDENTIFIER_FORMAT
       # @see OLD_IDENTIFIER_FORMAT
       def id?(id)
-        NEW_IDENTIFIER_FORMAT.match?(id) || OLD_IDENTIFIER_FORMAT.match?(id)
+        return true if NEW_IDENTIFIER_FORMAT.match? id
+        return true if OLD_IDENTIFIER_FORMAT.match?(id) && Arx::CATEGORIES.keys.include?(id.split('/').first)
+        false
       end
     end
   end

--- a/spec/arx/arx_spec.rb
+++ b/spec/arx/arx_spec.rb
@@ -34,6 +34,9 @@ describe Arx do
       context '(invalid)' do
         it { expect { Arx.search '1234.1234' }.to raise_error Error::MissingPaper }
       end
+      context '(invalid format)' do
+        it { expect { Arx.search 'abc' }.to raise_error ArgumentError }
+      end
     end
     context 'with multiple IDs' do
       context '(valid)' do
@@ -48,6 +51,9 @@ describe Arx do
 
         it { is_expected.to be_an Array }
         it { is_expected.to be_empty }
+      end
+      context '(invalid format)' do
+        it { expect { Arx.search '1105.5379', 'cond-mat/9609089', 'a' }.to raise_error ArgumentError }
       end
     end
     context 'with a predefined query' do

--- a/spec/arx/arx_spec.rb
+++ b/spec/arx/arx_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'matchers/paper'
+
+describe Arx do
+  context '.search' do
+    let :papers do
+      [
+        'Parallel Coordinate Descent for L1-Regularized Loss Minimization',
+        'Optical absorption of non-interacting tight-binding electrons in a Peierls-distorted chain at half band-filling'
+      ]
+    end
+
+    it { is_expected.to respond_to(:search).with(0..1).arguments }
+    it { is_expected.to respond_to(:search).with_unlimited_arguments }
+    it { is_expected.to respond_to(:search).with_keywords(:query) }
+    it { is_expected.to respond_to(:search).with_keywords(:sort_by) }
+    it { is_expected.to respond_to(:search).with_keywords(:sort_order) }
+    it { is_expected.to respond_to(:search).with_keywords(:query, :sort_by) }
+    it { is_expected.to respond_to(:search).with_keywords(:query, :sort_order) }
+    it { is_expected.to respond_to(:search).with_keywords(:sort_by, :sort_order) }
+    it { is_expected.to respond_to(:search).with_keywords(:query, :sort_by, :sort_order) }
+
+    context 'with a block' do
+      it { expect {|b| Arx.search &b}.to yield_control.once }
+      it { expect {|b| Arx.search &b}.to yield_with_args Query }
+    end
+    context 'with one ID' do
+      context '(valid)' do
+        subject { Arx.search '1105.5379' }
+
+        it { is_expected.to be_a Paper }
+        it { is_expected.to get_paper papers.first }
+      end
+      context '(invalid)' do
+        it { expect { Arx.search '1234.1234' }.to raise_error Error::MissingPaper }
+      end
+    end
+    context 'with multiple IDs' do
+      context '(valid)' do
+        subject { Arx.search '1105.5379', 'cond-mat/9609089' }
+
+        it { is_expected.to be_an Array }
+        it { is_expected.to all be_a Paper }
+        it { is_expected.to get_papers papers }
+      end
+      context '(invalid)' do
+        subject { Arx.search '1234.1234', 'invalid-category/1234567' }
+
+        it { is_expected.to be_an Array }
+        it { is_expected.to be_empty }
+      end
+    end
+    context 'with a predefined query' do
+      context '(valid)' do
+        subject { Query.new('1105.5379') }
+
+        context 'with a block' do
+          it { expect {|b| Arx.search(query: subject, &b)}.to yield_with_args subject }
+          it { expect(Arx.search(query: subject) {}).to get_papers papers.first }
+        end
+        context 'without a block' do
+          it { expect(Arx.search(query: subject)).to get_papers papers.first }
+        end
+      end
+      context '(invalid)' do
+        it { expect { Arx.search(query: String.new) }.to raise_error TypeError }
+      end
+    end
+  end
+
+  %i[find get].each do |alternative|
+    context ".#{alternative}" do
+      it "should alias .search" do
+        expect(subject.method(alternative).original_name).to eq :search
+      end
+    end
+  end
+end

--- a/spec/arx/arx_spec.rb
+++ b/spec/arx/arx_spec.rb
@@ -31,6 +31,12 @@ describe Arx do
         it { is_expected.to be_a Paper }
         it { is_expected.to get_paper papers.first }
       end
+      context '(valid URL)' do
+        subject { Arx.search 'https://arxiv.org/abs/1105.5379' }
+
+        it { is_expected.to be_a Paper }
+        it { is_expected.to get_paper papers.first }
+      end
       context '(invalid)' do
         it { expect { Arx.search '1234.1234' }.to raise_error Error::MissingPaper }
       end

--- a/spec/arx/arx_spec.rb
+++ b/spec/arx/arx_spec.rb
@@ -53,10 +53,7 @@ describe Arx do
         it { is_expected.to get_papers papers }
       end
       context '(invalid)' do
-        subject { Arx.search '1234.1234', 'invalid-category/1234567' }
-
-        it { is_expected.to be_an Array }
-        it { is_expected.to be_empty }
+        it { expect { Arx.search '1234.1234', 'invalid-category/1234567' }.to raise_error ArgumentError }
       end
       context '(invalid format)' do
         it { expect { Arx.search '1105.5379', 'cond-mat/9609089', 'a' }.to raise_error ArgumentError }

--- a/spec/arx/cleaner_spec.rb
+++ b/spec/arx/cleaner_spec.rb
@@ -125,28 +125,94 @@ describe Cleaner do
     context 'with version' do
       context 'URL' do
         context 'old format' do
-
+          urls[:old].each_with_index do |url, i|
+            if i.even?
+              it "should extract an ID from #{url.inspect}" do
+                expect(subject.extract_id url, version: true).to eq 'cond-mat/9609089'
+              end
+            else
+              it "should extract an ID from #{url.inspect}" do
+                expect(subject.extract_id url, version: true).to eq 'cond-mat/9609089v1'
+              end
+            end
+          end
         end
         context 'new format' do
-
+          urls[:new].each_with_index do |url, i|
+            if i.even?
+              it "should extract an ID from #{url.inspect}" do
+                expect(subject.extract_id url, version: true).to eq '1105.5379'
+              end
+            else
+              it "should extract an ID from #{url.inspect}" do
+                expect(subject.extract_id url, version: true).to eq '1105.5379v1'
+              end
+            end
+          end
         end
       end
       context 'ID' do
         context 'old format' do
-            it { expect { subject.extract_version 'cond-mat/9609089' }.to raise_error ArgumentError }
-            it { expect(subject.extract_version 'cond-mat/9609089v1').to eq 1 }
-            it { expect { subject.extract_version 'cs/0003044' }.to raise_error ArgumentError }
-            it { expect(subject.extract_version 'cs/0003044v10').to eq 10 }
-            it { expect { subject.extract_version 'hep-th/9711200' }.to raise_error ArgumentError }
-            it { expect(subject.extract_version 'hep-th/9711200v100').to eq 100 }
+          it { expect(subject.extract_id 'cond-mat/9609089').to eq 'cond-mat/9609089' }
+          it { expect(subject.extract_id 'cond-mat/9609089v1').to eq 'cond-mat/9609089' }
+          it { expect(subject.extract_id 'cs/0003044').to eq 'cs/0003044' }
+          it { expect(subject.extract_id 'cs/0003044v10').to eq 'cs/0003044' }
+          it { expect(subject.extract_id 'hep-th/9711200').to eq 'hep-th/9711200' }
+          it { expect(subject.extract_id 'hep-th/9711200v100').to eq 'hep-th/9711200' }
         end
         context 'new format' do
-
+          it { expect(subject.extract_id '1105.5379').to eq '1105.5379' }
+          it { expect(subject.extract_id '1105.5379v1').to eq '1105.5379' }
+          it { expect(subject.extract_id '1710.02185').to eq '1710.02185' }
+          it { expect(subject.extract_id '1710.02185v10').to eq '1710.02185' }
+          it { expect(subject.extract_id '1703.04834').to eq '1703.04834' }
+          it { expect(subject.extract_id '1703.04834v100').to eq '1703.04834' }
         end
       end
     end
   end
   context '.extract_version' do
-
+    context 'URL' do
+      context 'old format' do
+        urls[:old].each_with_index do |url, i|
+          if i.even?
+            it { expect { subject.extract_version url }.to raise_error ArgumentError }
+          else
+            it "should extract a version number from #{url.inspect}" do
+              expect(subject.extract_version url).to eq 1
+            end
+          end
+        end
+      end
+      context 'new format' do
+        urls[:new].each_with_index do |url, i|
+          if i.even?
+            it { expect { subject.extract_version url }.to raise_error ArgumentError }
+          else
+            it "should extract a version number from #{url.inspect}" do
+              expect(subject.extract_version url).to eq 1
+            end
+          end
+        end
+      end
+    end
+    context 'ID' do
+      context 'old format' do
+        it { expect { subject.extract_version 'cond-mat/9609089' }.to raise_error ArgumentError }
+        it { expect(subject.extract_version 'cond-mat/9609089v1').to eq 1 }
+        it { expect { subject.extract_version 'cs/0003044' }.to raise_error ArgumentError }
+        it { expect(subject.extract_version 'cs/0003044v10').to eq 10 }
+        it { expect { subject.extract_version 'hep-th/9711200' }.to raise_error ArgumentError }
+        it { expect(subject.extract_version 'hep-th/9711200v100').to eq 100 }
+      end
+      context 'new format' do
+        it { expect { subject.extract_version '1105.5379' }.to raise_error ArgumentError }
+        it { expect(subject.extract_version '1105.5379v1').to eq 1 }
+        it { expect { subject.extract_version '1710.02185' }.to raise_error ArgumentError }
+        it { expect(subject.extract_version '1710.02185v10').to eq 10 }
+        it { expect { subject.extract_version '1703.04834' }.to raise_error ArgumentError }
+        it { expect(subject.extract_version '1703.04834v100').to eq 100 }
+      end
+    end
   end
 end

--- a/spec/arx/cleaner_spec.rb
+++ b/spec/arx/cleaner_spec.rb
@@ -1,0 +1,152 @@
+require 'spec_helper'
+
+def urls
+  {
+    old: %w[
+      https://www.arxiv.org/abs/cond-mat/9609089/
+      https://www.arxiv.org/abs/cond-mat/9609089v1/
+      https://www.arxiv.org/abs/cond-mat/9609089
+      https://www.arxiv.org/abs/cond-mat/9609089v1
+      https://arxiv.org/abs/cond-mat/9609089/
+      https://arxiv.org/abs/cond-mat/9609089v1/
+      https://arxiv.org/abs/cond-mat/9609089
+      https://arxiv.org/abs/cond-mat/9609089v1
+      http://www.arxiv.org/abs/cond-mat/9609089/
+      http://www.arxiv.org/abs/cond-mat/9609089v1/
+      http://www.arxiv.org/abs/cond-mat/9609089
+      http://www.arxiv.org/abs/cond-mat/9609089v1
+      http://arxiv.org/abs/cond-mat/9609089/
+      http://arxiv.org/abs/cond-mat/9609089v1/
+      http://arxiv.org/abs/cond-mat/9609089
+      http://arxiv.org/abs/cond-mat/9609089v1
+      www.arxiv.org/abs/cond-mat/9609089/
+      www.arxiv.org/abs/cond-mat/9609089v1/
+      www.arxiv.org/abs/cond-mat/9609089
+      www.arxiv.org/abs/cond-mat/9609089v1
+      arxiv.org/abs/cond-mat/9609089/
+      arxiv.org/abs/cond-mat/9609089v1/
+      arxiv.org/abs/cond-mat/9609089
+      arxiv.org/abs/cond-mat/9609089v1
+    ],
+    new: %w[
+      https://www.arxiv.org/abs/1105.5379/
+      https://www.arxiv.org/abs/1105.5379v1/
+      https://www.arxiv.org/abs/1105.5379
+      https://www.arxiv.org/abs/1105.5379v1
+      https://arxiv.org/abs/1105.5379/
+      https://arxiv.org/abs/1105.5379v1/
+      https://arxiv.org/abs/1105.5379
+      https://arxiv.org/abs/1105.5379v1
+      http://www.arxiv.org/abs/1105.5379/
+      http://www.arxiv.org/abs/1105.5379v1/
+      http://www.arxiv.org/abs/1105.5379
+      http://www.arxiv.org/abs/1105.5379v1
+      http://arxiv.org/abs/1105.5379/
+      http://arxiv.org/abs/1105.5379v1/
+      http://arxiv.org/abs/1105.5379
+      http://arxiv.org/abs/1105.5379v1
+      www.arxiv.org/abs/1105.5379/
+      www.arxiv.org/abs/1105.5379v1/
+      www.arxiv.org/abs/1105.5379
+      www.arxiv.org/abs/1105.5379v1
+      arxiv.org/abs/1105.5379/
+      arxiv.org/abs/1105.5379v1/
+      arxiv.org/abs/1105.5379
+      arxiv.org/abs/1105.5379v1
+    ]
+  }
+end
+
+describe Cleaner do
+  subject { Cleaner }
+
+  context :URL_PREFIX do
+    urls.values.flatten.each do |url|
+      context(url) { it { expect(url).to match Cleaner::URL_PREFIX } }
+    end
+  end
+  context '.clean' do
+    [
+      {uncleaned: "This\nis\na\ntest.", cleaned: "This is a test."},
+      {uncleaned: "This\ris\ra\rtest.", cleaned: "This is a test."},
+      {uncleaned: "This\r\nis\r\na\r\ntest.", cleaned: "This is a test."},
+      {uncleaned: "  This\n\r    is\r\na test   ok. ", cleaned: "This is a test ok."},
+    ].each do |example|
+      it "should clean #{example[:uncleaned].inspect}" do
+        expect(subject.clean example[:uncleaned]).to eq example[:cleaned]
+      end
+    end
+  end
+  context '.extract_id' do
+    context 'without version' do
+      context '(invalid type)' do
+        it { expect { subject.extract_id 2 }.to raise_error TypeError }
+      end
+      context '(invalid)' do
+        it { expect { subject.extract_id ?a }.to raise_error ArgumentError }
+      end
+      context '(valid)' do
+        context 'URL' do
+          context 'old format' do
+            urls[:old].each do |url|
+              it "should extract an ID from #{url.inspect}" do
+                expect(subject.extract_id url).to eq 'cond-mat/9609089'
+              end
+            end
+          end
+          context 'new format' do
+            urls[:new].each do |url|
+              it "should extract an ID from #{url.inspect}" do
+                expect(subject.extract_id url).to eq '1105.5379'
+              end
+            end
+          end
+        end
+        context 'ID' do
+          context 'old format' do
+            it { expect(subject.extract_id 'cond-mat/9609089').to eq 'cond-mat/9609089' }
+            it { expect(subject.extract_id 'cond-mat/9609089v1').to eq 'cond-mat/9609089' }
+            it { expect(subject.extract_id 'cs/0003044').to eq 'cs/0003044' }
+            it { expect(subject.extract_id 'cs/0003044v10').to eq 'cs/0003044' }
+            it { expect(subject.extract_id 'hep-th/9711200').to eq 'hep-th/9711200' }
+            it { expect(subject.extract_id 'hep-th/9711200v100').to eq 'hep-th/9711200' }
+          end
+          context 'new format' do
+            it { expect(subject.extract_id '1105.5379').to eq '1105.5379' }
+            it { expect(subject.extract_id '1105.5379v1').to eq '1105.5379' }
+            it { expect(subject.extract_id '1710.02185').to eq '1710.02185' }
+            it { expect(subject.extract_id '1710.02185v10').to eq '1710.02185' }
+            it { expect(subject.extract_id '1703.04834').to eq '1703.04834' }
+            it { expect(subject.extract_id '1703.04834v100').to eq '1703.04834' }
+          end
+        end
+      end
+    end
+    context 'with version' do
+      context 'URL' do
+        context 'old format' do
+
+        end
+        context 'new format' do
+
+        end
+      end
+      context 'ID' do
+        context 'old format' do
+            it { expect { subject.extract_version 'cond-mat/9609089' }.to raise_error ArgumentError }
+            it { expect(subject.extract_version 'cond-mat/9609089v1').to eq 1 }
+            it { expect { subject.extract_version 'cs/0003044' }.to raise_error ArgumentError }
+            it { expect(subject.extract_version 'cs/0003044v10').to eq 10 }
+            it { expect { subject.extract_version 'hep-th/9711200' }.to raise_error ArgumentError }
+            it { expect(subject.extract_version 'hep-th/9711200v100').to eq 100 }
+        end
+        context 'new format' do
+
+        end
+      end
+    end
+  end
+  context '.extract_version' do
+
+  end
+end

--- a/spec/arx/entities/author_spec.rb
+++ b/spec/arx/entities/author_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Author do
+  subject { Author }
+
+  let :authors do
+    Arx.get('cond-mat/9609089', '1105.5379').map {|paper| paper.authors[1]}
+  end
+
+  context '#name' do
+    context 'cond-mat/9609089' do
+      it { expect(authors[0].name).to eq 'K. Bott' }
+    end
+    context '1105.5379' do
+      it { expect(authors[1].name).to eq 'Aapo Kyrola' }
+    end
+  end
+  context '#affiliated?' do
+    context 'cond-mat/9609089' do
+      it { expect(authors[0].affiliated?).to be true }
+    end
+    context '1105.5379' do
+      it { expect(authors[1].affiliated?).to be false }
+    end
+  end
+  context '#affiliations' do
+    context 'cond-mat/9609089' do
+      it { expect(authors[0].affiliations).to eq ["Philipps University Marburg, Germany"] }
+    end
+    context '1105.5379' do
+      it { expect(authors[1].affiliations).to be_empty }
+    end
+  end
+end

--- a/spec/arx/entities/category_spec.rb
+++ b/spec/arx/entities/category_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Category do
+  subject { Category }
+
+  let :categories do
+    Arx.get('cond-mat/9609089', '1105.5379').map {|paper| paper.categories.first}
+  end
+
+  context '#name' do
+    context 'cond-mat/9609089' do
+      it { expect(categories[0].name).to eq 'cond-mat' }
+    end
+    context '1105.5379' do
+      it { expect(categories[1].name).to eq 'cs.LG' }
+    end
+  end
+  context '#full_name' do
+    context 'cond-mat/9609089' do
+      it { expect(categories[0].full_name).to eq 'Condensed Matter' }
+    end
+    context '1105.5379' do
+      it { expect(categories[1].full_name).to eq 'Learning' }
+    end
+  end
+end

--- a/spec/arx/entities/category_spec.rb
+++ b/spec/arx/entities/category_spec.rb
@@ -14,6 +14,12 @@ describe Category do
     context '1105.5379' do
       it { expect(categories[1].name).to eq 'cs.LG' }
     end
+    context '1703.04834' do
+      subject { Arx.get('1703.04834').categories }
+
+      it { expect(subject[1].name).to eq '03D05' } # MSC class
+      it { expect(subject[2].name).to eq 'F.1.1; F.4.1' } # ACM classes
+    end
   end
   context '#full_name' do
     context 'cond-mat/9609089' do
@@ -21,6 +27,12 @@ describe Category do
     end
     context '1105.5379' do
       it { expect(categories[1].full_name).to eq 'Learning' }
+    end
+    context '1703.04834' do
+      subject { Arx.get('1703.04834').categories }
+
+      it { expect(subject[1].full_name).to be_nil } # MSC class
+      it { expect(subject[2].full_name).to be_nil } # ACM classes
     end
   end
 end

--- a/spec/arx/entities/paper_spec.rb
+++ b/spec/arx/entities/paper_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
-require 'matchers/paper'
 
 describe Paper do
   subject { Paper }
-  let(:papers) { Arx.get 'cond-mat/9609089', '1105.5379', '1710.02185' }
+
+  let :papers do
+    Arx.get 'cond-mat/9609089', '1105.5379', '1710.02185'
+  end
 
   context '#id' do
     context 'cond-mat/9609089' do
@@ -167,24 +169,24 @@ describe Paper do
   end
   context '#revision?' do
     context 'cond-mat/9609089' do
-      it { expect(papers[0].revision?).to eq false }
+      it { expect(papers[0].revision?).to be false }
     end
     context '1105.5379' do
-      it { expect(papers[1].revision?).to eq false }
+      it { expect(papers[1].revision?).to be false }
     end
     context '1710.02185' do
-      it { expect(papers[2].revision?).to eq true }
+      it { expect(papers[2].revision?).to be true }
     end
   end
   context '#comment?' do
     context 'cond-mat/9609089' do
-      it { expect(papers[0].comment?).to eq true }
+      it { expect(papers[0].comment?).to be true }
     end
     context '1105.5379' do
-      it { expect(papers[1].comment?).to eq false }
+      it { expect(papers[1].comment?).to be false }
     end
     context '1710.02185' do
-      it { expect(papers[2].comment?).to eq true }
+      it { expect(papers[2].comment?).to be true }
     end
   end
   context '#comment' do
@@ -200,13 +202,13 @@ describe Paper do
   end
   context '#journal?' do
     context 'cond-mat/9609089' do
-      it { expect(papers[0].journal?).to eq true }
+      it { expect(papers[0].journal?).to be true }
     end
     context '1105.5379' do
-      it { expect(papers[1].journal?).to eq true }
+      it { expect(papers[1].journal?).to be true }
     end
     context '1710.02185' do
-      it { expect(papers[2].journal?).to eq false }
+      it { expect(papers[2].journal?).to be false }
     end
   end
   context '#journal' do
@@ -222,13 +224,13 @@ describe Paper do
   end
   context '#pdf?' do
     context 'cond-mat/9609089' do
-      it { expect(papers[0].pdf?).to eq true }
+      it { expect(papers[0].pdf?).to be true }
     end
     context '1105.5379' do
-      it { expect(papers[1].pdf?).to eq true }
+      it { expect(papers[1].pdf?).to be true }
     end
     context '1710.02185' do
-      it { expect(papers[2].pdf?).to eq true }
+      it { expect(papers[2].pdf?).to be true }
     end
   end
   context '#pdf_url' do
@@ -244,13 +246,13 @@ describe Paper do
   end
   context '#doi?' do
     context 'cond-mat/9609089' do
-      it { expect(papers[0].doi?).to eq true }
+      it { expect(papers[0].doi?).to be true }
     end
     context '1105.5379' do
-      it { expect(papers[1].doi?).to eq false }
+      it { expect(papers[1].doi?).to be false }
     end
     context '1710.02185' do
-      it { expect(papers[2].doi?).to eq true }
+      it { expect(papers[2].doi?).to be true }
     end
   end
   context '#doi_url' do

--- a/spec/arx/entities/paper_spec.rb
+++ b/spec/arx/entities/paper_spec.rb
@@ -203,7 +203,7 @@ describe Paper do
       it { is_expected.to be_an Array }
       it { is_expected.to all be_an Category }
       it { expect(subject.map &:name).to eq ['cs.FL', '03D05', 'F.1.1; F.4.1'] }
-      it { expect(subject[1...2].map &:full_name).to all be nil } # MSC or ACM classes
+      it { expect(subject[1...2].map &:full_name).to all be_nil } # MSC or ACM classes
     end
   end
   context '#published_at' do

--- a/spec/arx/entities/paper_spec.rb
+++ b/spec/arx/entities/paper_spec.rb
@@ -4,29 +4,81 @@ describe Paper do
   subject { Paper }
 
   let :papers do
-    Arx.get 'cond-mat/9609089', '1105.5379', '1710.02185'
+    Arx.get 'cond-mat/9609089', '1105.5379', '1710.02185', '1703.04834'
   end
 
   context '#id' do
-    context 'cond-mat/9609089' do
-      it { expect(papers[0].id).to eq 'cond-mat/9609089v1' }
+    context 'without version' do
+      context 'cond-mat/9609089' do
+        it { expect(papers[0].id).to eq 'cond-mat/9609089' }
+      end
+      context '1105.5379' do
+        it { expect(papers[1].id).to eq '1105.5379' }
+      end
+      context '1710.02185' do
+        it { expect(papers[2].id).to eq '1710.02185' }
+      end
+      context '1703.04834' do
+        it { expect(papers[3].id).to eq '1703.04834' }
+      end
     end
-    context '1105.5379' do
-      it { expect(papers[1].id).to eq '1105.5379v1' }
-    end
-    context '1710.02185' do
-      it { expect(papers[2].id).to eq '1710.02185v3' }
+    context 'with version' do
+      context 'cond-mat/9609089' do
+        it { expect(papers[0].id version: true).to eq 'cond-mat/9609089v1' }
+      end
+      context '1105.5379' do
+        it { expect(papers[1].id version: true).to eq '1105.5379v1' }
+      end
+      context '1710.02185' do
+        it { expect(papers[2].id version: true).to eq '1710.02185v3' }
+      end
+      context '1703.04834' do
+        it { expect(papers[3].id version: true).to eq '1703.04834v1' }
+      end
     end
   end
   context '#url' do
+    context 'without version' do
+      context 'cond-mat/9609089' do
+        it { expect(papers[0].url).to eq 'http://arxiv.org/abs/cond-mat/9609089' }
+      end
+      context '1105.5379' do
+        it { expect(papers[1].url).to eq 'http://arxiv.org/abs/1105.5379' }
+      end
+      context '1710.02185' do
+        it { expect(papers[2].url).to eq 'http://arxiv.org/abs/1710.02185' }
+      end
+      context '1703.04834' do
+        it { expect(papers[3].url).to eq 'http://arxiv.org/abs/1703.04834' }
+      end
+    end
+    context 'with version' do
+      context 'cond-mat/9609089' do
+        it { expect(papers[0].url version: true).to eq 'http://arxiv.org/abs/cond-mat/9609089v1' }
+      end
+      context '1105.5379' do
+        it { expect(papers[1].url version: true).to eq 'http://arxiv.org/abs/1105.5379v1' }
+      end
+      context '1710.02185' do
+        it { expect(papers[2].url version: true).to eq 'http://arxiv.org/abs/1710.02185v3' }
+      end
+      context '1703.04834' do
+        it { expect(papers[3].url version: true).to eq 'http://arxiv.org/abs/1703.04834v1' }
+      end
+    end
+  end
+  context '#version' do
     context 'cond-mat/9609089' do
-      it { expect(papers[0].url).to eq 'http://arxiv.org/abs/cond-mat/9609089v1' }
+      it { expect(papers[0].version).to eq 1 }
     end
     context '1105.5379' do
-      it { expect(papers[1].url).to eq 'http://arxiv.org/abs/1105.5379v1' }
+      it { expect(papers[1].version).to eq 1 }
     end
     context '1710.02185' do
-      it { expect(papers[2].url).to eq 'http://arxiv.org/abs/1710.02185v3' }
+      it { expect(papers[2].version).to eq 3 }
+    end
+    context '1703.04834' do
+      it { expect(papers[3].version).to eq 1 }
     end
   end
   context '#title' do
@@ -39,6 +91,9 @@ describe Paper do
     context '1710.02185' do
       it { expect(papers[2].title).to eq "Effects of Data Quality Vetoes on a Search for Compact Binary Coalescences in Advanced LIGO's First Observing Run" }
     end
+    context '1703.04834' do
+      it { expect(papers[3].title).to eq 'A Quasi-Linear Time Algorithm Deciding Whether Weak Büchi Automata Reading Vectors of Reals Recognize Saturated Languages' }
+    end
   end
   context '#summary' do
     context 'cond-mat/9609089' do
@@ -49,6 +104,9 @@ describe Paper do
     end
     context '1710.02185' do
       it { expect(papers[2].summary).to eq "The first observing run of Advanced LIGO spanned 4 months, from September 12, 2015 to January 19, 2016, during which gravitational waves were directly detected from two binary black hole systems, namely GW150914 and GW151226. Confident detection of gravitational waves requires an understanding of instrumental transients and artifacts that can reduce the sensitivity of a search. Studies of the quality of the detector data yield insights into the cause of instrumental artifacts and data quality vetoes specific to a search are produced to mitigate the effects of problematic data. In this paper, the systematic removal of noisy data from analysis time is shown to improve the sensitivity of searches for compact binary coalescences. The output of the PyCBC pipeline, which is a python-based code package used to search for gravitational wave signals from compact binary coalescences, is used as a metric for improvement. GW150914 was a loud enough signal that removing noisy data did not improve its significance. However, the removal of data with excess noise decreased the false alarm rate of GW151226 by more than two orders of magnitude, from 1 in 770 years to less than 1 in 186000 years." }
+    end
+    context '1703.04834' do
+      it { expect(papers[3].summary).to eq "This work considers weak deterministic B\\\"uchi automata reading encodings of non-negative $d$-vectors of reals in a fixed base. A saturated language is a language which contains all encoding of elements belonging to a set of $d$-vectors of reals. A Real Vector Automaton is an automaton which recognizes a saturated language. It is explained how to decide in quasi-linear time whether a minimal weak deterministic B\\\"uchi automaton is a Real Vector Automaton. The problem is solved both for the two standard encodings of vectors of numbers: the sequential encoding and the parallel encoding. This algorithm runs in linear time for minimal weak B\\\"uchi automata accepting set of reals. Finally, the same problem is also solved for parallel encoding of automata reading vectors of relative reals." }
     end
   end
   context '#abstract' do
@@ -78,6 +136,13 @@ describe Paper do
       it { is_expected.to all be_an Author }
       it { expect(subject.size).to eq 960 } # 960 authors, no way I'm listing all of them!
     end
+    context '1703.04834' do
+      subject { papers[3].authors }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all be_an Author }
+      it { expect(subject.map &:name).to eq ['Arthur Milchior'] }
+    end
   end
   context '#primary_category' do
     context 'cond-mat/9609089' do
@@ -97,6 +162,12 @@ describe Paper do
 
       it { is_expected.to be_a Category }
       it { expect(subject.name).to eq 'gr-qc' }
+    end
+    context '1703.04834' do
+      subject { papers[3].primary_category }
+
+      it { is_expected.to be_a Category }
+      it { expect(subject.name).to eq 'cs.FL' }
     end
   end
   context '#category' do
@@ -126,6 +197,14 @@ describe Paper do
       it { is_expected.to all be_an Category }
       it { expect(subject.map &:name).to eq %w[gr-qc astro-ph.IM] }
     end
+    context '1703.04834' do
+      subject { papers[3].categories }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all be_an Category }
+      it { expect(subject.map &:name).to eq ['cs.FL', '03D05', 'F.1.1; F.4.1'] }
+      it { expect(subject[1...2].map &:full_name).to all be nil } # MSC or ACM classes
+    end
   end
   context '#published_at' do
     context 'cond-mat/9609089' do
@@ -145,6 +224,12 @@ describe Paper do
 
       it { is_expected.to be_a DateTime }
       it { expect(subject.to_s).to eq '2017-10-05T19:18:51+00:00' }
+    end
+    context '1703.04834' do
+      subject { papers[3].published_at }
+
+      it { is_expected.to be_a DateTime }
+      it { expect(subject.to_s).to eq '2017-03-14T23:41:24+00:00' }
     end
   end
   context '#updated_at' do
@@ -166,6 +251,12 @@ describe Paper do
       it { is_expected.to be_a DateTime }
       it { expect(subject.to_s).to eq '2017-11-07T22:45:22+00:00' }
     end
+    context '1703.04834' do
+      subject { papers[3].updated_at }
+
+      it { is_expected.to be_a DateTime }
+      it { expect(subject.to_s).to eq '2017-03-14T23:41:24+00:00' }
+    end
   end
   context '#revision?' do
     context 'cond-mat/9609089' do
@@ -176,6 +267,9 @@ describe Paper do
     end
     context '1710.02185' do
       it { expect(papers[2].revision?).to be true }
+    end
+    context '1703.04834' do
+      it { expect(papers[3].revision?).to be false }
     end
   end
   context '#comment?' do
@@ -188,6 +282,9 @@ describe Paper do
     context '1710.02185' do
       it { expect(papers[2].comment?).to be true }
     end
+    context '1703.04834' do
+      it { expect(papers[3].comment?).to be false }
+    end
   end
   context '#comment' do
     context 'cond-mat/9609089' do
@@ -198,6 +295,9 @@ describe Paper do
     end
     context '1710.02185' do
       it { expect(papers[2].comment).to eq '31 pages, 17 figures; corrected author list' }
+    end
+    context '1703.04834' do
+      it { expect { papers[3].comment }.to raise_error Error::MissingField }
     end
   end
   context '#journal?' do
@@ -210,6 +310,9 @@ describe Paper do
     context '1710.02185' do
       it { expect(papers[2].journal?).to be false }
     end
+    context '1703.04834' do
+      it { expect(papers[3].journal?).to be false }
+    end
   end
   context '#journal' do
     context 'cond-mat/9609089' do
@@ -220,6 +323,9 @@ describe Paper do
     end
     context '1710.02185' do
       it { expect { papers[2].journal }.to raise_error Error::MissingField }
+    end
+    context '1703.04834' do
+      it { expect { papers[3].journal }.to raise_error Error::MissingField }
     end
   end
   context '#pdf?' do
@@ -232,6 +338,9 @@ describe Paper do
     context '1710.02185' do
       it { expect(papers[2].pdf?).to be true }
     end
+    context '1703.04834' do
+      it { expect(papers[3].pdf?).to be true }
+    end
   end
   context '#pdf_url' do
     context 'cond-mat/9609089' do
@@ -242,6 +351,9 @@ describe Paper do
     end
     context '1710.02185' do
       it { expect(papers[2].pdf_url).to eq 'http://arxiv.org/pdf/1710.02185v3' }
+    end
+    context '1703.04834' do
+      it { expect(papers[3].pdf_url).to eq 'http://arxiv.org/pdf/1703.04834v1' }
     end
   end
   context '#doi?' do
@@ -254,6 +366,9 @@ describe Paper do
     context '1710.02185' do
       it { expect(papers[2].doi?).to be true }
     end
+    context '1703.04834' do
+      it { expect(papers[3].doi?).to be false }
+    end
   end
   context '#doi_url' do
     context 'cond-mat/9609089' do
@@ -264,6 +379,9 @@ describe Paper do
     end
     context '1710.02185' do
       it { expect(papers[2].doi_url).to eq 'http://dx.doi.org/10.1088/1361-6382/aaaafa' }
+    end
+    context '1703.04834' do
+      it { expect { papers[3].doi_url }.to raise_error Error::MissingLink }
     end
   end
 end

--- a/spec/arx/inspector_spec.rb
+++ b/spec/arx/inspector_spec.rb
@@ -1,54 +1,52 @@
 require 'spec_helper'
 
-describe Inspector do
-  subject do
-    Test = Class.new do
-      include Inspector
-      define_method(:a) { }
-      define_method(:b) { raise StandardError.new }
-      define_method(:c) { :c }
-      define_method(:d) { ?d.ord }
-      define_method(:e) { ?e }
-    end
-  end
+class Test
+  include Inspector
+  define_method(:a) { }
+  define_method(:b) { raise StandardError.new }
+  define_method(:c) { :c }
+  define_method(:d) { ?d.ord }
+  define_method(:e) { ?e }
+end
 
+describe Inspector do
   context 'no methods' do
-    before { subject.send :inspector }
+    before { Test.send :inspector }
 
     it do
-      instance = subject.new
+      instance = Test.new
       expect(instance.inspect).to eq "#<Test:#{instance.object_id} >"
     end
   end
   context 'erroneous methods' do
-    before { subject.send :inspector, :b }
+    before { Test.send :inspector, :b }
 
     it do
-      instance = subject.new
+      instance = Test.new
       expect(instance.inspect).to eq "#<Test:#{instance.object_id} >"
     end
   end
   context 'nil-return methods' do
-    before { subject.send :inspector, :a }
+    before { Test.send :inspector, :a }
 
     it do
-      instance = subject.new
+      instance = Test.new
       expect(instance.inspect).to eq "#<Test:#{instance.object_id} a=nil>"
     end
   end
   context 'valid-return methods' do
-    before { subject.send :inspector, *%i[c d e] }
+    before { Test.send :inspector, *%i[c d e] }
 
     it do
-      instance = subject.new
+      instance = Test.new
       expect(instance.inspect).to eq "#<Test:#{instance.object_id} c=:c, d=100, e=\"e\">"
     end
   end
   context 'all methods' do
-    before { subject.send :inspector, *%i[a b c d e] }
+    before { Test.send :inspector, *%i[a b c d e] }
 
     it do
-      instance = subject.new
+      instance = Test.new
       expect(instance.inspect).to eq "#<Test:#{instance.object_id} a=nil, c=:c, d=100, e=\"e\">"
     end
   end

--- a/spec/arx/inspector_spec.rb
+++ b/spec/arx/inspector_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Inspector do
+  subject do
+    Test = Class.new do
+      include Inspector
+      define_method(:a) { }
+      define_method(:b) { raise StandardError.new }
+      define_method(:c) { :c }
+      define_method(:d) { ?d.ord }
+      define_method(:e) { ?e }
+    end
+  end
+
+  context 'no methods' do
+    before { subject.send :inspector }
+
+    it do
+      instance = subject.new
+      expect(instance.inspect).to eq "#<Test:#{instance.object_id} >"
+    end
+  end
+  context 'erroneous methods' do
+    before { subject.send :inspector, :b }
+
+    it do
+      instance = subject.new
+      expect(instance.inspect).to eq "#<Test:#{instance.object_id} >"
+    end
+  end
+  context 'nil-return methods' do
+    before { subject.send :inspector, :a }
+
+    it do
+      instance = subject.new
+      expect(instance.inspect).to eq "#<Test:#{instance.object_id} a=nil>"
+    end
+  end
+  context 'valid-return methods' do
+    before { subject.send :inspector, *%i[c d e] }
+
+    it do
+      instance = subject.new
+      expect(instance.inspect).to eq "#<Test:#{instance.object_id} c=:c, d=100, e=\"e\">"
+    end
+  end
+  context 'all methods' do
+    before { subject.send :inspector, *%i[a b c d e] }
+
+    it do
+      instance = subject.new
+      expect(instance.inspect).to eq "#<Test:#{instance.object_id} a=nil, c=:c, d=100, e=\"e\">"
+    end
+  end
+end

--- a/spec/arx/paper_spec.rb
+++ b/spec/arx/paper_spec.rb
@@ -1,0 +1,267 @@
+require 'spec_helper'
+require 'matchers/paper'
+
+describe Paper do
+  subject { Paper }
+  let(:papers) { Arx.get 'cond-mat/9609089', '1105.5379', '1710.02185' }
+
+  context '#id' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].id).to eq 'cond-mat/9609089v1' }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].id).to eq '1105.5379v1' }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].id).to eq '1710.02185v3' }
+    end
+  end
+  context '#url' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].url).to eq 'http://arxiv.org/abs/cond-mat/9609089v1' }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].url).to eq 'http://arxiv.org/abs/1105.5379v1' }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].url).to eq 'http://arxiv.org/abs/1710.02185v3' }
+    end
+  end
+  context '#title' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].title).to eq 'Optical absorption of non-interacting tight-binding electrons in a Peierls-distorted chain at half band-filling' }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].title).to eq 'Parallel Coordinate Descent for L1-Regularized Loss Minimization' }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].title).to eq "Effects of Data Quality Vetoes on a Search for Compact Binary Coalescences in Advanced LIGO's First Observing Run" }
+    end
+  end
+  context '#summary' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].summary).to eq "In this first of three articles on the optical absorption of electrons in half-filled Peierls-distorted chains we present analytical results for non-interacting tight-binding electrons. We carefully derive explicit expressions for the current operator, the dipole transition matrix elements, and the optical absorption for electrons with a cosine dispersion relation of band width $W$ and dimerization parameter $\\delta$. New correction (``$\\eta$''-)terms to the current operator are identified. A broad band-to-band transition is found in the frequency range $W\\delta < \\omega < W$ whose shape is determined by the joint density of states for the upper and lower Peierls subbands and the strong momentum dependence of the transition matrix elements." }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].summary).to eq "We propose Shotgun, a parallel coordinate descent algorithm for minimizing L1-regularized losses. Though coordinate descent seems inherently sequential, we prove convergence bounds for Shotgun which predict linear speedups, up to a problem-dependent limit. We present a comprehensive empirical study of Shotgun for Lasso and sparse logistic regression. Our theoretical predictions on the potential for parallelism closely match behavior on real data. Shotgun outperforms other published solvers on a range of large problems, proving to be one of the most scalable algorithms for L1." }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].summary).to eq "The first observing run of Advanced LIGO spanned 4 months, from September 12, 2015 to January 19, 2016, during which gravitational waves were directly detected from two binary black hole systems, namely GW150914 and GW151226. Confident detection of gravitational waves requires an understanding of instrumental transients and artifacts that can reduce the sensitivity of a search. Studies of the quality of the detector data yield insights into the cause of instrumental artifacts and data quality vetoes specific to a search are produced to mitigate the effects of problematic data. In this paper, the systematic removal of noisy data from analysis time is shown to improve the sensitivity of searches for compact binary coalescences. The output of the PyCBC pipeline, which is a python-based code package used to search for gravitational wave signals from compact binary coalescences, is used as a metric for improvement. GW150914 was a loud enough signal that removing noisy data did not improve its significance. However, the removal of data with excess noise decreased the false alarm rate of GW151226 by more than two orders of magnitude, from 1 in 770 years to less than 1 in 186000 years." }
+    end
+  end
+  context '#abstract' do
+    it "should alias #summary" do
+      expect(subject.instance_method(:abstract).original_name).to eq :summary
+    end
+  end
+  context '#authors' do
+    context 'cond-mat/9609089' do
+      subject { papers[0].authors }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all be_an Author }
+      it { expect(subject.map &:name).to eq ['F. Gebhard', 'K. Bott', 'M. Scheidler', 'P. Thomas', 'S. W. Koch'] }
+    end
+    context '1105.5379' do
+      subject { papers[1].authors }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all be_an Author }
+      it { expect(subject.map &:name).to eq ['Joseph K. Bradley', 'Aapo Kyrola', 'Danny Bickson', 'Carlos Guestrin'] }
+    end
+    context '1710.02185' do
+      subject { papers[2].authors }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all be_an Author }
+      it { expect(subject.size).to eq 960 } # 960 authors, no way I'm listing all of them!
+    end
+  end
+  context '#primary_category' do
+    context 'cond-mat/9609089' do
+      subject { papers[0].primary_category }
+
+      it { is_expected.to be_a Category }
+      it { expect(subject.name).to eq 'cond-mat' }
+    end
+    context '1105.5379' do
+      subject { papers[1].primary_category }
+
+      it { is_expected.to be_a Category }
+      it { expect(subject.name).to eq 'cs.LG' }
+    end
+    context '1710.02185' do
+      subject { papers[2].primary_category }
+
+      it { is_expected.to be_a Category }
+      it { expect(subject.name).to eq 'gr-qc' }
+    end
+  end
+  context '#category' do
+    it "should alias #primary_category" do
+      expect(subject.instance_method(:category).original_name).to eq :primary_category
+    end
+  end
+  context '#categories' do
+    context 'cond-mat/9609089' do
+      subject { papers[0].categories }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all be_an Category }
+      it { expect(subject.map &:name).to eq %w[cond-mat chem-ph] }
+    end
+    context '1105.5379' do
+      subject { papers[1].categories }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all be_an Category }
+      it { expect(subject.map &:name).to eq %w[cs.LG cs.IT math.IT] }
+    end
+    context '1710.02185' do
+      subject { papers[2].categories }
+
+      it { is_expected.to be_an Array }
+      it { is_expected.to all be_an Category }
+      it { expect(subject.map &:name).to eq %w[gr-qc astro-ph.IM] }
+    end
+  end
+  context '#published_at' do
+    context 'cond-mat/9609089' do
+      subject { papers[0].published_at }
+
+      it { is_expected.to be_a DateTime }
+      it { expect(subject.to_s).to eq '1996-09-10T13:52:54+00:00' }
+    end
+    context '1105.5379' do
+      subject { papers[1].published_at }
+
+      it { is_expected.to be_a DateTime }
+      it { expect(subject.to_s).to eq '2011-05-26T19:19:30+00:00' }
+    end
+    context '1710.02185' do
+      subject { papers[2].published_at }
+
+      it { is_expected.to be_a DateTime }
+      it { expect(subject.to_s).to eq '2017-10-05T19:18:51+00:00' }
+    end
+  end
+  context '#updated_at' do
+    context 'cond-mat/9609089' do
+      subject { papers[0].updated_at }
+
+      it { is_expected.to be_a DateTime }
+      it { expect(subject.to_s).to eq '1996-09-10T13:52:54+00:00' }
+    end
+    context '1105.5379' do
+      subject { papers[1].updated_at }
+
+      it { is_expected.to be_a DateTime }
+      it { expect(subject.to_s).to eq '2011-05-26T19:19:30+00:00' }
+    end
+    context '1710.02185' do
+      subject { papers[2].updated_at }
+
+      it { is_expected.to be_a DateTime }
+      it { expect(subject.to_s).to eq '2017-11-07T22:45:22+00:00' }
+    end
+  end
+  context '#revision?' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].revision?).to eq false }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].revision?).to eq false }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].revision?).to eq true }
+    end
+  end
+  context '#comment?' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].comment?).to eq true }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].comment?).to eq false }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].comment?).to eq true }
+    end
+  end
+  context '#comment' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].comment).to eq '17 pages REVTEX 3.0, 2 postscript figures; hardcopy versions before May 96 are obsolete; accepted for publication in The Philosophical Magazine B' }
+    end
+    context '1105.5379' do
+      it { expect { papers[1].comment }.to raise_error Error::MissingField }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].comment).to eq '31 pages, 17 figures; corrected author list' }
+    end
+  end
+  context '#journal?' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].journal?).to eq true }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].journal?).to eq true }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].journal?).to eq false }
+    end
+  end
+  context '#journal' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].journal).to eq 'Phil. Mag. B 75, pp. 1-12 (1997)' }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].journal).to eq 'In the 28th International Conference on Machine Learning, July 2011, Washington, USA' }
+    end
+    context '1710.02185' do
+      it { expect { papers[2].journal }.to raise_error Error::MissingField }
+    end
+  end
+  context '#pdf?' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].pdf?).to eq true }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].pdf?).to eq true }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].pdf?).to eq true }
+    end
+  end
+  context '#pdf_url' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].pdf_url).to eq 'http://arxiv.org/pdf/cond-mat/9609089v1' }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].pdf_url).to eq 'http://arxiv.org/pdf/1105.5379v1' }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].pdf_url).to eq 'http://arxiv.org/pdf/1710.02185v3' }
+    end
+  end
+  context '#doi?' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].doi?).to eq true }
+    end
+    context '1105.5379' do
+      it { expect(papers[1].doi?).to eq false }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].doi?).to eq true }
+    end
+  end
+  context '#doi_url' do
+    context 'cond-mat/9609089' do
+      it { expect(papers[0].doi_url).to eq 'http://dx.doi.org/10.1080/13642819708205700' }
+    end
+    context '1105.5379' do
+      it { expect { papers[1].doi_url }.to raise_error Error::MissingLink }
+    end
+    context '1710.02185' do
+      it { expect(papers[2].doi_url).to eq 'http://dx.doi.org/10.1088/1361-6382/aaaafa' }
+    end
+  end
+end

--- a/spec/arx/query/query_spec.rb
+++ b/spec/arx/query/query_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe Query do
+  context '.initialize' do
+    subject { Query }
+
+    it { is_expected.to respond_to(:new).with(0..1).arguments }
+    it { is_expected.to respond_to(:new).with_unlimited_arguments }
+
+    context 'with no arguments' do
+      it { expect(subject.new.to_s).to eq 'sortBy=relevance&sortOrder=descending' }
+    end
+    context 'with IDs' do
+      context '1105.5379' do
+        it { expect(subject.new('1105.5379').to_s).to eq 'sortBy=relevance&sortOrder=descending&id_list=1105.5379' }
+      end
+      context 'cond-mat/9609089' do
+        it { expect(subject.new('cond-mat/9609089').to_s).to eq 'sortBy=relevance&sortOrder=descending&id_list=cond-mat/9609089' }
+      end
+      context '1105.5379, cond-mat/9609089 and cs/0003044' do
+        it { expect(subject.new(*%w[1105.5379 cond-mat/9609089 cs/0003044]).to_s).to eq 'sortBy=relevance&sortOrder=descending&id_list=1105.5379,cond-mat/9609089,cs/0003044' }
+      end
+    end
+    context 'with key-word arguments' do
+      context '(invalid)' do
+        context :sort_by do
+          it { expect { subject.new(sort_by: 'invalid') }.to raise_error TypeError }
+          it { expect { subject.new(sort_by: :invalid) }.to raise_error ArgumentError }
+        end
+        context :sort_order do
+          it { expect { subject.new(sort_order: 'invalid') }.to raise_error TypeError }
+          it { expect { subject.new(sort_order: :invalid) }.to raise_error ArgumentError }
+        end
+      end
+      context '(valid)' do
+        context :sort_by do
+          Arx::Query::SORT_BY.each do |key, field|
+            it { expect(subject.new(sort_by: key).to_s).to eq "sortBy=#{field}&sortOrder=descending" }
+          end
+        end
+        context :sort_order do
+          Arx::Query::SORT_ORDER.each do |key, field|
+            it { expect(subject.new(sort_order: key).to_s).to eq "sortBy=relevance&sortOrder=#{field}" }
+          end
+        end
+        context "sort_by and sort_order" do
+          Arx::Query::SORT_BY.each do |sort_by_key, sort_by_field|
+            Arx::Query::SORT_ORDER.each do |sort_order_key, sort_order_field|
+              it { expect(subject.new(sort_by: sort_by_key, sort_order: sort_order_key).to_s).to eq "sortBy=#{sort_by_field}&sortOrder=#{sort_order_field}" }
+            end
+          end
+        end
+      end
+    end
+    context 'with IDs and key-word arguments' do
+      it { expect(subject.new('1105.5379', 'cond-mat/9609089', sort_by: :date_submitted, sort_order: :ascending).to_s).to eq 'sortBy=submittedDate&sortOrder=ascending&id_list=1105.5379,cond-mat/9609089' }
+    end
+  end
+
+  %i[and or and_not].each do |connective|
+    context "##{connective}" do
+      let(:query) { Query.new }
+
+      it {  }
+    end
+  end
+end

--- a/spec/matchers/paper.rb
+++ b/spec/matchers/paper.rb
@@ -1,0 +1,17 @@
+RSpec::Matchers.define :get_paper do |expected|
+  match {|actual| actual.title == expected}
+  failure_message do |actual|
+    "expected paper: \n\t\"#{expected}\"\ngot:\n\t\"#{actual.title}\""
+  end
+end
+
+RSpec::Matchers.define :get_papers do |*expected|
+  match {|actual| actual.map(&:title) == expected.flatten}
+  failure_message do |actual|
+    output = "expected papers:\n\t"
+    output << expected.flatten.map {|title| "\"#{title}\""}.join(",\n\t")
+    output << "\ngot:\n\t"
+    output << actual.map {|paper| "\"#{paper.title}\""}.join(",\n\t")
+    output
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,6 @@ $LOAD_PATH.unshift File.join __dir__, '..', 'lib'
 require 'bundler/setup'
 require 'arx'
 
-# Load support files from spec/support
-Dir.glob File.join(__dir__, 'support', '*.rb'), &method(:require)
-
 RSpec.configure do |config|
   # Configure RSpec here...
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,4 @@
 $LOAD_PATH.unshift File.join __dir__, '..', 'lib'
 require 'bundler/setup'
 require 'arx'
-
-RSpec.configure do |config|
-  # Configure RSpec here...
-end
-
 include Arx


### PR DESCRIPTION
- Implement all tests.
- Remove version number from `Paper#id` and `Paper#url`.
- Add `Paper#version` for the paper's version number.
- Redefine `Paper#revision?` to use `Paper#version`.
- Add `Cleaner.extract_id` and `Cleaner.extract_version`.
- Make `Query#add_connective` always return `self`.
- Redefine `Arx.search` to user `Paper.parse`'s `search` key-word argument.
