### PR TITLE
[release] 1.0.0 🎉 (stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 1.0.0
+
+#### Major changes
+
+- Change `Query` connective instance methods ([#38](https://github.com/eonu/arx/pull/38)):
+  - `#&` -> `#and`
+  - `#|` -> `#or`
+  - `#!` -> `#and_not`
+- Split version number from paper identifier in `Paper` (add `version` key-word argument to `#id` and `#url`, and add `#version`). ([#39](https://github.com/eonu/arx/pull/39))
+- Add `Cleaner.extract_id` and `Cleaner.extract_version`. ([#39](https://github.com/eonu/arx/pull/39))
+- Make `Query#add_connective` always return `self`. ([#40](https://github.com/eonu/arx/pull/40))
+- Redefine `Arx.search` to user `Paper.parse`'s `search` key-word argument. ([#40](https://github.com/eonu/arx/pull/40))
+- Implement all tests. ([#40](https://github.com/eonu/arx/pull/40))
+
+#### Minor changes
+
+- Change declared regular expression literals from `%r""` to standard `//`. ([#39](https://github.com/eonu/arx/pull/39))
+- Remove `#extract_id` from `Query` and use `Cleaner.extract_id` instead. ([#39](https://github.com/eonu/arx/pull/39))
+- Redefine `Paper#revision?` to use the new `#version` instead of `#updated_at` and`#published_at`. ([#39](https://github.com/eonu/arx/pull/39))
+
 # 0.3.2
 
 #### Major changes

--- a/lib/arx/version.rb
+++ b/lib/arx/version.rb
@@ -4,9 +4,9 @@ module Arx
 
   # The current version of Arx.
   VERSION = {
-    major: 0,
-    minor: 3,
-    patch: 2,
+    major: 1,
+    minor: 0,
+    patch: 0,
     meta: nil,
   }.compact.values.join('.').freeze
 end


### PR DESCRIPTION
# Major changes

- Change `Query` connective instance methods ([#38](https://github.com/eonu/arx/pull/38)):
  - `#&` -> `#and`
  - `#|` -> `#or`
  - `#!` -> `#and_not`
- Split version number from paper identifier in `Paper` (add `version` key-word argument to `#id` and `#url`, and add `#version`). ([#39](https://github.com/eonu/arx/pull/39))
- Add `Cleaner.extract_id` and `Cleaner.extract_version`. ([#39](https://github.com/eonu/arx/pull/39))
- Make `Query#add_connective` always return `self`. ([#40](https://github.com/eonu/arx/pull/40))
- Redefine `Arx.search` to user `Paper.parse`'s `search` key-word argument. ([#40](https://github.com/eonu/arx/pull/40))
- Implement all tests. ([#40](https://github.com/eonu/arx/pull/40))

# Minor changes

- Change declared regular expression literals from `%r""` to standard `//`. ([#39](https://github.com/eonu/arx/pull/39))
- Remove `#extract_id` from `Query` and use `Cleaner.extract_id` instead. ([#39](https://github.com/eonu/arx/pull/39))
- Redefine `Paper#revision?` to use the new `#version` instead of `#updated_at` and`#published_at`. ([#39](https://github.com/eonu/arx/pull/39))