### PR TITLE
[feature:spec] Add coveralls support

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: FJPJ2lFiRJMyHk8ioOdFOG8XgGth5gsgQ

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![License](https://img.shields.io/github/license/eonu/arx.svg)](https://github.com/eonu/arx/blob/master/LICENSE)
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/e94073dfa8c3e2442298/maintainability)](https://codeclimate.com/github/eonu/arx/maintainability)
-[![Documentation](https://img.shields.io/badge/docs-rubydoc.info-blue.svg)](https://www.rubydoc.info/github/eonu/arx/master/toplevel)
 [![Build Status](https://travis-ci.com/eonu/arx.svg?branch=master)](https://travis-ci.com/eonu/arx)
 [![Coverage Status](https://coveralls.io/repos/github/eonu/arx/badge.svg?branch=feature%2Fcoveralls)](https://coveralls.io/github/eonu/arx?branch=feature%2Fcoveralls)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/e94073dfa8c3e2442298/maintainability)](https://codeclimate.com/github/eonu/arx/maintainability)
 [![Documentation](https://img.shields.io/badge/docs-rubydoc.info-blue.svg)](https://www.rubydoc.info/github/eonu/arx/master/toplevel)
 [![Build Status](https://travis-ci.com/eonu/arx.svg?branch=master)](https://travis-ci.com/eonu/arx)
+[![Coverage Status](https://coveralls.io/repos/github/eonu/arx/badge.svg?branch=feature%2Fcoveralls)](https://coveralls.io/github/eonu/arx?branch=feature%2Fcoveralls)
 
 **A Ruby interface for querying academic papers on the arXiv search API.**
 

--- a/arx.gemspec
+++ b/arx.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'thor', '~> 0.20'
   spec.add_development_dependency 'rspec', '~> 3.7'
+  spec.add_development_dependency 'coveralls', '~> 0.8'
 
   spec.metadata = {
     'source_code_uri' => spec.homepage,

--- a/arx.gemspec
+++ b/arx.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'thor', '~> 0.20'
+  spec.add_development_dependency 'thor', '~> 0.19.4'
   spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
+  spec.add_development_dependency 'coveralls', '0.8.22'
 
   spec.metadata = {
     'source_code_uri' => spec.homepage,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
+require 'coveralls'
+Coveralls.wear!
+
 $LOAD_PATH.unshift File.join __dir__, '..', 'lib'
 require 'bundler/setup'
 require 'arx'
+
 include Arx


### PR DESCRIPTION
- Add support for the `coveralls` gem (`.coveralls.yml` configuration file).
- Add code coverage badge to `README.md`.
- Remove documentation badge from top of `README.md`.