### PR TITLE
[patch:ci] Add ruby-2.6 + remove script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: ruby
 before_install: gem update --system
 rvm:
   - 2.5
+  - 2.6
   - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 before_install: gem update --system
-script: bundle exec rake
 rvm:
   - 2.5
   - ruby-head

--- a/arx.gemspec
+++ b/arx.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri', '~> 1.10'
   spec.add_runtime_dependency 'nokogiri-happymapper', '~> 0.8'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'thor', '~> 0.19.4'
   spec.add_development_dependency 'rspec', '~> 3.7'


### PR DESCRIPTION
- Add RVM ruby version `2.6`.
- Remove `script` field (as this already defaults to `rake`). 
- Change `bundler` requirement to `>= 1.17` in `arx.gemspec`.