### PR TITLE
[patch:lib] Remove Arx.find alias

### DIFF
--- a/lib/arx.rb
+++ b/lib/arx.rb
@@ -76,7 +76,6 @@ module Arx
       results
     end
 
-    alias_method :find, :search
     alias_method :get, :search
   end
 end

--- a/spec/arx/arx_spec.rb
+++ b/spec/arx/arx_spec.rb
@@ -85,11 +85,9 @@ describe Arx do
     end
   end
 
-  %i[find get].each do |alternative|
-    context ".#{alternative}" do
-      it "should alias .search" do
-        expect(subject.method(alternative).original_name).to eq :search
-      end
+  context ".get" do
+    it "should alias .search" do
+      expect(subject.method(:get).original_name).to eq :search
     end
   end
 end


### PR DESCRIPTION
- Remove `Arx.find` alias of `Arx.search`.