### PR TITLE
[feature:gem] Add bin/console for gem debugging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ namespace :gem do
 
   desc 'Debug the gem (load into IRB)'
   task :debug do
-    exec 'bundle exec rake install && irb -I lib/arx.rb -r arx'
+    exec 'bin/console'
   end
 
   desc 'Prepare a new gem release'

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$: << "./lib"
+
+require 'bundler/setup'
+require 'irb'
+require 'arx'
+
+IRB.start


### PR DESCRIPTION
- Add `bin/console` for gem debugging.
- Modify `gem:debug` rake task to run `bin/console`.