### PR TITLE
[feature:lib] Add serialization support

### DIFF
--- a/arx.gemspec
+++ b/arx.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'thor', '~> 0.19.4'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'coveralls', '0.8.22'
+  spec.add_development_dependency 'awesome_print', '~> 1.8'
 
   spec.metadata = {
     'source_code_uri' => spec.homepage,

--- a/arx.gemspec
+++ b/arx.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'thor', '~> 0.19.4'
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'coveralls', '0.8.22'
-  spec.add_development_dependency 'awesome_print', '~> 1.8'
 
   spec.metadata = {
     'source_code_uri' => spec.homepage,

--- a/lib/arx.rb
+++ b/lib/arx.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'cgi'
+require 'json'
 require 'nokogiri'
 require 'open-uri'
 require 'happymapper'

--- a/lib/arx/entities/author.rb
+++ b/lib/arx/entities/author.rb
@@ -5,6 +5,9 @@ module Arx
     include HappyMapper
     include Inspector
 
+    # The attributes of an arXiv paper author.
+    ATTRIBUTES = %i[name affiliated? affiliations]
+
     tag 'author'
 
     # @!method name
@@ -23,6 +26,12 @@ module Arx
       !affiliations.empty?
     end
 
-    inspector :name, :affiliated?, :affiliations
+    # Serializes the {Author} object into a +Hash+.
+    # @return [Hash]
+    def to_h
+      Hash[*ATTRIBUTES.map {|_| [_, send(_)]}.flatten(1)]
+    end
+
+    inspector *ATTRIBUTES
   end
 end

--- a/lib/arx/entities/author.rb
+++ b/lib/arx/entities/author.rb
@@ -5,7 +5,7 @@ module Arx
     include HappyMapper
     include Inspector
 
-    # The attributes of an arXiv paper author.
+    # The attributes of an arXiv paper's author.
     ATTRIBUTES = %i[name affiliated? affiliations]
 
     tag 'author'
@@ -27,9 +27,24 @@ module Arx
     end
 
     # Serializes the {Author} object into a +Hash+.
+    #
     # @return [Hash]
     def to_h
       Hash[*ATTRIBUTES.map {|_| [_, send(_)]}.flatten(1)]
+    end
+
+    # Serializes the {Author} object into a valid JSON hash.
+    #
+    # @return [Hash] The resulting JSON hash.
+    def as_json
+      JSON.parse to_json
+    end
+
+    # Serializes the {Author} object into a valid JSON string.
+    #
+    # @return [String] The resulting JSON string.
+    def to_json
+      to_h.to_json
     end
 
     inspector *ATTRIBUTES

--- a/lib/arx/entities/category.rb
+++ b/lib/arx/entities/category.rb
@@ -5,7 +5,7 @@ module Arx
     include HappyMapper
     include Inspector
 
-    # The attributes of an arXiv paper category.
+    # The attributes of an arXiv paper's category.
     ATTRIBUTES = %i[name full_name]
 
     tag 'category'
@@ -23,9 +23,24 @@ module Arx
     end
 
     # Serializes the {Category} object into a +Hash+.
+    #
     # @return [Hash]
     def to_h
       Hash[*ATTRIBUTES.map {|_| [_, send(_)]}.flatten(1)]
+    end
+
+    # Serializes the {Category} object into a valid JSON hash.
+    #
+    # @return [Hash] The resulting JSON hash.
+    def as_json
+      JSON.parse to_json
+    end
+
+    # Serializes the {Category} object into a valid JSON string.
+    #
+    # @return [String] The resulting JSON string.
+    def to_json
+      to_h.to_json
     end
 
     inspector *ATTRIBUTES

--- a/lib/arx/entities/category.rb
+++ b/lib/arx/entities/category.rb
@@ -5,6 +5,9 @@ module Arx
     include HappyMapper
     include Inspector
 
+    # The attributes of an arXiv paper category.
+    ATTRIBUTES = %i[name full_name]
+
     tag 'category'
 
     # @!method name
@@ -19,6 +22,12 @@ module Arx
       CATEGORIES[name]
     end
 
-    inspector :name, :full_name
+    # Serializes the {Category} object into a +Hash+.
+    # @return [Hash]
+    def to_h
+      Hash[*ATTRIBUTES.map {|_| [_, send(_)]}.flatten(1)]
+    end
+
+    inspector *ATTRIBUTES
   end
 end

--- a/lib/arx/entities/paper.rb
+++ b/lib/arx/entities/paper.rb
@@ -173,6 +173,7 @@ module Arx
     end
 
     # Serializes the {Paper} object into a +Hash+.
+    #
     # @param deep [Boolean] Whether to deep-serialize {Author} and {Category} objects.
     # @return [Hash]
     def to_h(deep = false)
@@ -183,6 +184,22 @@ module Arx
           hash[:primary_category] = hash[:primary_category].to_h
         end
       end
+    end
+
+    # Serializes the {Paper} object into a valid JSON hash.
+    #
+    # @note Deep-serializes {Author} and {Category} objects.
+    # @return [Hash] The resulting JSON hash.
+    def as_json
+      JSON.parse to_json
+    end
+
+    # Serializes the {Paper} object into a valid JSON string.
+    #
+    # @note Deep-serializes {Author} and {Category} objects.
+    # @return [String] The resulting JSON string.
+    def to_json
+      to_h(true).to_json
     end
 
     inspector *ATTRIBUTES

--- a/spec/arx/entities/author_spec.rb
+++ b/spec/arx/entities/author_spec.rb
@@ -31,4 +31,22 @@ describe Author do
       it { expect(authors[1].affiliations).to be_empty }
     end
   end
+  #Arx.get('cond-mat/9609089', '1105.5379', '1710.02185', '1703.04834', '1809.09415', 'hep-th/9711200').each do |paper|
+  context '#to_h' do
+    context 'cond-mat/9609089' do
+      subject { Arx.get('cond-mat/9609089').authors.first.to_h }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a Symbol }
+      it { expect(subject).to eq({affiliated?: true, affiliations: ["ILL Grenoble, France"], name: "F. Gebhard"}) }
+    end
+    context '1105.5379' do
+      subject { Arx.get('1105.5379').authors.first.to_h }
+      it { expect(subject).to eq({ name: "Joseph K. Bradley", affiliated?: false, affiliations: []})
+    end
+    context '1710.02185' do
+      subject { Arx.get('1710.02185').authors.first.to_h }
+      it { expect(subject).to eq({name: "The LIGO Scientific Collaboration", affiliated?: false, affiliations: []})
+    end
+  end
 end

--- a/spec/arx/entities/author_spec.rb
+++ b/spec/arx/entities/author_spec.rb
@@ -42,11 +42,11 @@ describe Author do
     end
     context '1105.5379' do
       subject { Arx.get('1105.5379').authors.first.to_h }
-      it { expect(subject).to eq({ name: "Joseph K. Bradley", affiliated?: false, affiliations: []})
+      it { expect(subject).to eq({ name: "Joseph K. Bradley", affiliated?: false, affiliations: []}) }
     end
     context '1710.02185' do
       subject { Arx.get('1710.02185').authors.first.to_h }
-      it { expect(subject).to eq({name: "The LIGO Scientific Collaboration", affiliated?: false, affiliations: []})
+      it { expect(subject).to eq({name: "The LIGO Scientific Collaboration", affiliated?: false, affiliations: []}) }
     end
   end
 end

--- a/spec/arx/entities/author_spec.rb
+++ b/spec/arx/entities/author_spec.rb
@@ -31,22 +31,53 @@ describe Author do
       it { expect(authors[1].affiliations).to be_empty }
     end
   end
-  #Arx.get('cond-mat/9609089', '1105.5379', '1710.02185', '1703.04834', '1809.09415', 'hep-th/9711200').each do |paper|
   context '#to_h' do
     context 'cond-mat/9609089' do
-      subject { Arx.get('cond-mat/9609089').authors.first.to_h }
+      subject { authors[0].to_h }
 
       it { is_expected.to be_a Hash }
       it { expect(subject.keys).to all be_a Symbol }
-      it { expect(subject).to eq({affiliated?: true, affiliations: ["ILL Grenoble, France"], name: "F. Gebhard"}) }
+      it { is_expected.to eq({affiliated?: true, affiliations: ["Philipps University Marburg, Germany"], name: "K. Bott"}) }
     end
     context '1105.5379' do
-      subject { Arx.get('1105.5379').authors.first.to_h }
-      it { expect(subject).to eq({ name: "Joseph K. Bradley", affiliated?: false, affiliations: []}) }
+      subject { authors[1].to_h }
+
+      it { is_expected.to eq({name: "Aapo Kyrola", affiliated?: false, affiliations: []}) }
     end
     context '1710.02185' do
       subject { Arx.get('1710.02185').authors.first.to_h }
-      it { expect(subject).to eq({name: "The LIGO Scientific Collaboration", affiliated?: false, affiliations: []}) }
+
+      it { is_expected.to eq({name: "The LIGO Scientific Collaboration", affiliated?: false, affiliations: []}) }
+    end
+  end
+  context '#as_json' do
+    context 'cond-mat/9609089' do
+      subject { authors[0].as_json }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a String }
+      it { is_expected.to eq({'affiliated?'=>true, 'affiliations'=>["Philipps University Marburg, Germany"], 'name'=>"K. Bott"}) }
+    end
+    context '1105.5379' do
+      subject { authors[1].as_json }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a String }
+      it { is_expected.to eq({'name'=>"Aapo Kyrola", 'affiliated?'=>false, 'affiliations'=>[]}) }
+    end
+  end
+  context '#to_json' do
+    context 'cond-mat/9609089' do
+      subject { authors[0].to_json }
+
+      it { is_expected.to be_a String }
+      it { is_expected.to eq "{\"name\":\"K. Bott\",\"affiliated?\":true,\"affiliations\":[\"Philipps University Marburg, Germany\"]}" }
+    end
+    context '1105.5379' do
+      subject { authors[1].to_json }
+
+      it { is_expected.to be_a String }
+      it { is_expected.to eq "{\"name\":\"Aapo Kyrola\",\"affiliated?\":false,\"affiliations\":[]}" }
     end
   end
 end

--- a/spec/arx/entities/category_spec.rb
+++ b/spec/arx/entities/category_spec.rb
@@ -37,19 +37,85 @@ describe Category do
   end
   context '#to_h' do
     context 'cond-mat/9609089' do
-      subject { Arx.get('cond-mat/9609089').primary_category.to_h }
+      subject { categories[0].to_h }
 
       it { is_expected.to be_a Hash }
       it { expect(subject.keys).to all be_a Symbol }
-      it { expect(subject).to eq({full_name: "Condensed Matter", name: "cond-mat"}) }
+      it { is_expected.to eq({full_name: "Condensed Matter", name: "cond-mat"}) }
     end
     context '1105.5379' do
-      subject { Arx.get('1105.5379').primary_category.to_h }
-      it { expect(subject).to eq({full_name: "Learning", name: "cs.LG"}) }
+      subject { categories[1].to_h }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a Symbol }
+      it { is_expected.to eq({full_name: "Learning", name: "cs.LG"}) }
     end
     context '1710.02185' do
       subject { Arx.get('1710.02185').primary_category.to_h }
-      it { expect(subject).to eq({full_name: "General Relativity and Quantum Cosmology", name: "gr-qc"}) }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a Symbol }
+      it { is_expected.to eq({full_name: "General Relativity and Quantum Cosmology", name: "gr-qc"}) }
+    end
+  end
+  context '#as_json' do
+    context 'cond-mat/9609089' do
+      subject { categories[0].as_json }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a String }
+      it { is_expected.to eq({"full_name"=>"Condensed Matter", "name"=>"cond-mat"}) }
+    end
+    context '1105.5379' do
+      subject { categories[1].as_json }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a String }
+      it { is_expected.to eq({"full_name"=>"Learning", "name"=>"cs.LG"}) }
+    end
+    context '1703.04834' do
+      context 'MSC' do
+        subject { Arx.get('1703.04834').categories[1].as_json }
+
+        it { is_expected.to be_a Hash }
+        it { expect(subject.keys).to all be_a String }
+        it { is_expected.to eq({"full_name"=>nil, "name"=>"03D05"}) }
+      end
+      context 'ACM' do
+        subject { Arx.get('1703.04834').categories[2].as_json }
+
+        it { is_expected.to be_a Hash }
+        it { expect(subject.keys).to all be_a String }
+        it { is_expected.to eq({"full_name"=>nil, "name"=>"F.1.1; F.4.1"}) }
+      end
+    end
+  end
+  context '#to_json' do
+    context 'cond-mat/9609089' do
+      subject { categories[0].to_json }
+
+      it { is_expected.to be_a String }
+      it { is_expected.to eq("{\"name\":\"cond-mat\",\"full_name\":\"Condensed Matter\"}") }
+    end
+    context '1105.5379' do
+      subject { categories[1].to_json }
+
+      it { is_expected.to be_a String }
+      it { is_expected.to eq("{\"name\":\"cs.LG\",\"full_name\":\"Learning\"}") }
+    end
+    context '1703.04834' do
+      context 'MSC' do
+        subject { Arx.get('1703.04834').categories[1].to_json }
+
+        it { is_expected.to be_a String }
+        it { is_expected.to eq("{\"name\":\"03D05\",\"full_name\":null}") }
+      end
+      context 'ACM' do
+        subject { Arx.get('1703.04834').categories[2].to_json }
+
+        it { is_expected.to be_a String }
+        it { is_expected.to eq("{\"name\":\"F.1.1; F.4.1\",\"full_name\":null}") }
+      end
     end
   end
 end

--- a/spec/arx/entities/category_spec.rb
+++ b/spec/arx/entities/category_spec.rb
@@ -35,4 +35,21 @@ describe Category do
       it { expect(subject[2].full_name).to be_nil } # ACM classes
     end
   end
+  context '#to_h' do
+    context 'cond-mat/9609089' do
+      subject { Arx.get('cond-mat/9609089').primary_category.to_h }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a Symbol }
+      it { expect(subject).to eq({full_name: "Condensed Matter", name: "cond-mat"}) }
+    end
+    context '1105.5379' do
+      subject { Arx.get('1105.5379').primary_category.to_h }
+      it { expect(subject).to eq({full_name: "Learning", name: "cs.LG"}) }
+    end
+    context '1710.02185' do
+      subject { Arx.get('1710.02185').primary_category.to_h }
+      it { expect(subject).to eq({full_name: "General Relativity and Quantum Cosmology", name: "gr-qc"}) }
+    end
+  end
 end

--- a/spec/arx/entities/paper_spec.rb
+++ b/spec/arx/entities/paper_spec.rb
@@ -386,10 +386,8 @@ describe Paper do
   end
   context '#to_h' do
     context 'cond-mat/9609089' do
-      let(:paper) { Arx.get('cond-mat/9609089') }
-
       context 'deep: true' do
-        subject { paper.to_h(true) }
+        subject { papers[0].to_h(true) }
 
         it { is_expected.to be_a Hash }
         it { expect(subject.keys).to all be_a Symbol }
@@ -427,7 +425,7 @@ describe Paper do
         end
       end
       context 'deep: false' do
-        subject { paper.to_h(false) }
+        subject { papers[0].to_h(false) }
 
         it { is_expected.to be_a Hash }
         it { expect(subject.keys).to all be_a Symbol }
@@ -457,10 +455,8 @@ describe Paper do
       end
     end
     context '1105.5379' do
-      let(:paper) { Arx.get('1105.5379') }
-
       context 'deep: true' do
-        subject { paper.to_h(true) }
+        subject { papers[1].to_h(true) }
 
         it { is_expected.to be_a Hash }
         it { expect(subject.keys).to all be_a Symbol }
@@ -496,7 +492,7 @@ describe Paper do
         end
       end
       context 'deep: false' do
-        subject { paper.to_h(false) }
+        subject { papers[1].to_h(false) }
 
         it { is_expected.to be_a Hash }
         it { expect(subject.keys).to all be_a Symbol }

--- a/spec/arx/entities/paper_spec.rb
+++ b/spec/arx/entities/paper_spec.rb
@@ -384,4 +384,144 @@ describe Paper do
       it { expect { papers[3].doi_url }.to raise_error Error::MissingLink }
     end
   end
+  context '#to_h' do
+    context 'cond-mat/9609089' do
+      let(:paper) { Arx.get('cond-mat/9609089') }
+
+      context 'deep: true' do
+        subject { paper.to_h(true) }
+
+        it { is_expected.to be_a Hash }
+        it { expect(subject.keys).to all be_a Symbol }
+        it do
+          expect(subject).to eq({
+            id: "cond-mat/9609089",
+            url: "http://arxiv.org/abs/cond-mat/9609089",
+            version: 1,
+            revision?: false,
+            title: "Optical absorption of non-interacting tight-binding electrons in a Peierls-distorted chain at half band-filling",
+            summary: "In this first of three articles on the optical absorption of electrons in half-filled Peierls-distorted chains we present analytical results for non-interacting tight-binding electrons. We carefully derive explicit expressions for the current operator, the dipole transition matrix elements, and the optical absorption for electrons with a cosine dispersion relation of band width $W$ and dimerization parameter $\\delta$. New correction (``$\\eta$''-)terms to the current operator are identified. A broad band-to-band transition is found in the frequency range $W\\delta < \\omega < W$ whose shape is determined by the joint density of states for the upper and lower Peierls subbands and the strong momentum dependence of the transition matrix elements.",
+            authors: [
+              {name: "F. Gebhard", affiliated?: true, affiliations: ["ILL Grenoble, France"]},
+              {name: "K. Bott", affiliated?: true, affiliations: ["Philipps University Marburg, Germany"]},
+              {name: "M. Scheidler", affiliated?: true, affiliations: ["Philipps University Marburg, Germany"]},
+              {name: "P. Thomas", affiliated?: true, affiliations: ["Philipps University Marburg, Germany"]},
+              {name: "S. W. Koch", affiliated?: true, affiliations: ["Philipps University Marburg, Germany"]}
+            ],
+            primary_category: {name: "cond-mat", full_name: "Condensed Matter"},
+            categories: [
+              {name: "cond-mat", full_name: "Condensed Matter"},
+              {name: "chem-ph", full_name: nil}
+            ],
+            published_at: DateTime.parse('1996-09-10T13:52:54+00:00'),
+            updated_at: DateTime.parse('1996-09-10T13:52:54+00:00'),
+            comment?: true,
+            comment: "17 pages REVTEX 3.0, 2 postscript figures; hardcopy versions before May 96 are obsolete; accepted for publication in The Philosophical Magazine B",
+            journal?: true,
+            journal: "Phil. Mag. B 75, pp. 1-12 (1997)",
+            pdf?: true,
+            pdf_url: "http://arxiv.org/pdf/cond-mat/9609089v1",
+            doi?: true,
+            doi_url: "http://dx.doi.org/10.1080/13642819708205700"
+          })
+        end
+      end
+      context 'deep: false' do
+        subject { paper.to_h(false) }
+
+        it { is_expected.to be_a Hash }
+        it { expect(subject.keys).to all be_a Symbol }
+        it { expect(subject[:authors]).to all be_an Author }
+        it { expect(subject[:categories]).to all be_a Category }
+        it { expect(subject[:primary_category]).to be_a Category }
+        it do
+          expect(subject).to include({
+            id: "cond-mat/9609089",
+            url: "http://arxiv.org/abs/cond-mat/9609089",
+            version: 1,
+            revision?: false,
+            title: "Optical absorption of non-interacting tight-binding electrons in a Peierls-distorted chain at half band-filling",
+            summary: "In this first of three articles on the optical absorption of electrons in half-filled Peierls-distorted chains we present analytical results for non-interacting tight-binding electrons. We carefully derive explicit expressions for the current operator, the dipole transition matrix elements, and the optical absorption for electrons with a cosine dispersion relation of band width $W$ and dimerization parameter $\\delta$. New correction (``$\\eta$''-)terms to the current operator are identified. A broad band-to-band transition is found in the frequency range $W\\delta < \\omega < W$ whose shape is determined by the joint density of states for the upper and lower Peierls subbands and the strong momentum dependence of the transition matrix elements.",
+            published_at: DateTime.parse('1996-09-10T13:52:54+00:00'),
+            updated_at: DateTime.parse('1996-09-10T13:52:54+00:00'),
+            comment?: true,
+            comment: "17 pages REVTEX 3.0, 2 postscript figures; hardcopy versions before May 96 are obsolete; accepted for publication in The Philosophical Magazine B",
+            journal?: true,
+            journal: "Phil. Mag. B 75, pp. 1-12 (1997)",
+            pdf?: true,
+            pdf_url: "http://arxiv.org/pdf/cond-mat/9609089v1",
+            doi?: true,
+            doi_url: "http://dx.doi.org/10.1080/13642819708205700"
+          })
+        end
+      end
+    end
+    context '1105.5379' do
+      let(:paper) { Arx.get('1105.5379') }
+
+      context 'deep: true' do
+        subject { paper.to_h(true) }
+
+        it { is_expected.to be_a Hash }
+        it { expect(subject.keys).to all be_a Symbol }
+        it do
+          expect(subject).to eq({
+            id: "1105.5379",
+            url: "http://arxiv.org/abs/1105.5379",
+            version: 1,
+            revision?: false,
+            title: "Parallel Coordinate Descent for L1-Regularized Loss Minimization",
+            summary: "We propose Shotgun, a parallel coordinate descent algorithm for minimizing L1-regularized losses. Though coordinate descent seems inherently sequential, we prove convergence bounds for Shotgun which predict linear speedups, up to a problem-dependent limit. We present a comprehensive empirical study of Shotgun for Lasso and sparse logistic regression. Our theoretical predictions on the potential for parallelism closely match behavior on real data. Shotgun outperforms other published solvers on a range of large problems, proving to be one of the most scalable algorithms for L1.",
+            authors: [
+              {name: "Joseph K. Bradley", affiliated?: false, affiliations: []},
+              {name: "Aapo Kyrola", affiliated?: false, affiliations: []},
+              {name: "Danny Bickson", affiliated?: false, affiliations: []},
+              {name: "Carlos Guestrin", affiliated?: false, affiliations: []}
+            ],
+            primary_category: {name: "cs.LG", full_name: "Learning"},
+            categories: [
+              {name: "cs.LG", full_name: "Learning"},
+              {name: "cs.IT", full_name: "Information Theory"},
+              {name: "math.IT", full_name: "Information Theory"}
+            ],
+            published_at: DateTime.parse('2011-05-26T19:19:30+00:00'),
+            updated_at: DateTime.parse('2011-05-26T19:19:30+00:00'),
+            comment?: false,
+            journal?: true,
+            journal: "In the 28th International Conference on Machine Learning, July 2011, Washington, USA",
+            pdf?: true,
+            pdf_url: "http://arxiv.org/pdf/1105.5379v1",
+            doi?: false
+          })
+        end
+      end
+      context 'deep: false' do
+        subject { paper.to_h(false) }
+
+        it { is_expected.to be_a Hash }
+        it { expect(subject.keys).to all be_a Symbol }
+        it { expect(subject[:authors]).to all be_an Author }
+        it { expect(subject[:categories]).to all be_a Category }
+        it { expect(subject[:primary_category]).to be_a Category }
+        it do
+          expect(subject).to include({
+            id: "1105.5379",
+            url: "http://arxiv.org/abs/1105.5379",
+            version: 1,
+            revision?: false,
+            title: "Parallel Coordinate Descent for L1-Regularized Loss Minimization",
+            summary: "We propose Shotgun, a parallel coordinate descent algorithm for minimizing L1-regularized losses. Though coordinate descent seems inherently sequential, we prove convergence bounds for Shotgun which predict linear speedups, up to a problem-dependent limit. We present a comprehensive empirical study of Shotgun for Lasso and sparse logistic regression. Our theoretical predictions on the potential for parallelism closely match behavior on real data. Shotgun outperforms other published solvers on a range of large problems, proving to be one of the most scalable algorithms for L1.",
+            published_at: DateTime.parse('2011-05-26T19:19:30+00:00'),
+            updated_at: DateTime.parse('2011-05-26T19:19:30+00:00'),
+            comment?: false,
+            journal?: true,
+            journal: "In the 28th International Conference on Machine Learning, July 2011, Washington, USA",
+            pdf?: true,
+            pdf_url: "http://arxiv.org/pdf/1105.5379v1",
+            doi?: false
+          })
+        end
+      end
+    end
+  end
 end

--- a/spec/arx/entities/paper_spec.rb
+++ b/spec/arx/entities/paper_spec.rb
@@ -392,7 +392,7 @@ describe Paper do
         it { is_expected.to be_a Hash }
         it { expect(subject.keys).to all be_a Symbol }
         it do
-          expect(subject).to eq({
+          is_expected.to eq({
             id: "cond-mat/9609089",
             url: "http://arxiv.org/abs/cond-mat/9609089",
             version: 1,
@@ -433,7 +433,7 @@ describe Paper do
         it { expect(subject[:categories]).to all be_a Category }
         it { expect(subject[:primary_category]).to be_a Category }
         it do
-          expect(subject).to include({
+          is_expected.to include({
             id: "cond-mat/9609089",
             url: "http://arxiv.org/abs/cond-mat/9609089",
             version: 1,
@@ -461,7 +461,7 @@ describe Paper do
         it { is_expected.to be_a Hash }
         it { expect(subject.keys).to all be_a Symbol }
         it do
-          expect(subject).to eq({
+          is_expected.to eq({
             id: "1105.5379",
             url: "http://arxiv.org/abs/1105.5379",
             version: 1,
@@ -500,7 +500,7 @@ describe Paper do
         it { expect(subject[:categories]).to all be_a Category }
         it { expect(subject[:primary_category]).to be_a Category }
         it do
-          expect(subject).to include({
+          is_expected.to include({
             id: "1105.5379",
             url: "http://arxiv.org/abs/1105.5379",
             version: 1,
@@ -518,6 +518,92 @@ describe Paper do
           })
         end
       end
+    end
+  end
+  context '#as_json' do
+    context 'cond-mat/9609089' do
+      subject { papers[0].as_json }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a String }
+      it do
+        is_expected.to eq({
+          "id"=>"cond-mat/9609089",
+          "url"=>"http://arxiv.org/abs/cond-mat/9609089",
+          "version"=>1,
+          "revision?"=>false,
+          "title"=>"Optical absorption of non-interacting tight-binding electrons in a Peierls-distorted chain at half band-filling",
+          "summary"=>"In this first of three articles on the optical absorption of electrons in half-filled Peierls-distorted chains we present analytical results for non-interacting tight-binding electrons. We carefully derive explicit expressions for the current operator, the dipole transition matrix elements, and the optical absorption for electrons with a cosine dispersion relation of band width $W$ and dimerization parameter $\\delta$. New correction (``$\\eta$''-)terms to the current operator are identified. A broad band-to-band transition is found in the frequency range $W\\delta < \\omega < W$ whose shape is determined by the joint density of states for the upper and lower Peierls subbands and the strong momentum dependence of the transition matrix elements.",
+          "authors"=>[
+            {"name"=>"F. Gebhard", "affiliated?"=>true, "affiliations"=>["ILL Grenoble, France"]},
+            {"name"=>"K. Bott", "affiliated?"=>true, "affiliations"=>["Philipps University Marburg, Germany"]},
+            {"name"=>"M. Scheidler", "affiliated?"=>true, "affiliations"=>["Philipps University Marburg, Germany"]},
+            {"name"=>"P. Thomas", "affiliated?"=>true, "affiliations"=>["Philipps University Marburg, Germany"]},
+            {"name"=>"S. W. Koch", "affiliated?"=>true, "affiliations"=>["Philipps University Marburg, Germany"]}
+          ],
+          "primary_category"=>{"name"=>"cond-mat", "full_name"=>"Condensed Matter"},
+          "categories"=>[
+            {"name"=>"cond-mat", "full_name"=>"Condensed Matter"},
+            {"name"=>"chem-ph", "full_name"=>nil}
+          ],
+          "published_at"=>"1996-09-10T13:52:54+00:00",
+          "updated_at"=>"1996-09-10T13:52:54+00:00",
+          "comment?"=>true,
+          "comment"=>"17 pages REVTEX 3.0, 2 postscript figures; hardcopy versions before May 96 are obsolete; accepted for publication in The Philosophical Magazine B",
+          "journal?"=>true,
+          "journal"=>"Phil. Mag. B 75, pp. 1-12 (1997)",
+          "pdf?"=>true,
+          "pdf_url"=>"http://arxiv.org/pdf/cond-mat/9609089v1",
+          "doi?"=>true,
+          "doi_url"=>"http://dx.doi.org/10.1080/13642819708205700"
+        })
+      end
+    end
+    context '1703.04834' do
+      subject { papers[3].as_json }
+
+      it { is_expected.to be_a Hash }
+      it { expect(subject.keys).to all be_a String }
+      it do
+        is_expected.to eq({
+          "id"=>"1703.04834",
+          "url"=>"http://arxiv.org/abs/1703.04834",
+          "version"=>1,
+          "revision?"=>false,
+          "title"=>"A Quasi-Linear Time Algorithm Deciding Whether Weak Büchi Automata Reading Vectors of Reals Recognize Saturated Languages",
+          "summary"=>"This work considers weak deterministic B\\\"uchi automata reading encodings of non-negative $d$-vectors of reals in a fixed base. A saturated language is a language which contains all encoding of elements belonging to a set of $d$-vectors of reals. A Real Vector Automaton is an automaton which recognizes a saturated language. It is explained how to decide in quasi-linear time whether a minimal weak deterministic B\\\"uchi automaton is a Real Vector Automaton. The problem is solved both for the two standard encodings of vectors of numbers: the sequential encoding and the parallel encoding. This algorithm runs in linear time for minimal weak B\\\"uchi automata accepting set of reals. Finally, the same problem is also solved for parallel encoding of automata reading vectors of relative reals.",
+          "authors"=>[
+            {"name"=>"Arthur Milchior", "affiliated?"=>false, "affiliations"=>[]}
+          ],
+          "primary_category"=>{"name"=>"cs.FL", "full_name"=>"Formal Languages and Automata Theory"},
+          "categories"=>[
+            {"name"=>"cs.FL", "full_name"=>"Formal Languages and Automata Theory"},
+            {"name"=>"03D05", "full_name"=>nil},
+            {"name"=>"F.1.1; F.4.1", "full_name"=>nil}
+          ],
+          "published_at"=>"2017-03-14T23:41:24+00:00",
+          "updated_at"=>"2017-03-14T23:41:24+00:00",
+          "comment?"=>false,
+          "journal?"=>false,
+          "pdf?"=>true,
+          "pdf_url"=>"http://arxiv.org/pdf/1703.04834v1",
+          "doi?"=>false
+        })
+      end
+    end
+  end
+  context '#to_json' do
+    context 'cond-mat/9609089' do
+      subject { papers[0].to_json }
+
+      it { is_expected.to be_a String }
+      it { is_expected.to eq("{\"id\":\"cond-mat/9609089\",\"url\":\"http://arxiv.org/abs/cond-mat/9609089\",\"version\":1,\"revision?\":false,\"title\":\"Optical absorption of non-interacting tight-binding electrons in a Peierls-distorted chain at half band-filling\",\"summary\":\"In this first of three articles on the optical absorption of electrons in half-filled Peierls-distorted chains we present analytical results for non-interacting tight-binding electrons. We carefully derive explicit expressions for the current operator, the dipole transition matrix elements, and the optical absorption for electrons with a cosine dispersion relation of band width $W$ and dimerization parameter $\\\\delta$. New correction (``$\\\\eta$''-)terms to the current operator are identified. A broad band-to-band transition is found in the frequency range $W\\\\delta < \\\\omega < W$ whose shape is determined by the joint density of states for the upper and lower Peierls subbands and the strong momentum dependence of the transition matrix elements.\",\"authors\":[{\"name\":\"F. Gebhard\",\"affiliated?\":true,\"affiliations\":[\"ILL Grenoble, France\"]},{\"name\":\"K. Bott\",\"affiliated?\":true,\"affiliations\":[\"Philipps University Marburg, Germany\"]},{\"name\":\"M. Scheidler\",\"affiliated?\":true,\"affiliations\":[\"Philipps University Marburg, Germany\"]},{\"name\":\"P. Thomas\",\"affiliated?\":true,\"affiliations\":[\"Philipps University Marburg, Germany\"]},{\"name\":\"S. W. Koch\",\"affiliated?\":true,\"affiliations\":[\"Philipps University Marburg, Germany\"]}],\"primary_category\":{\"name\":\"cond-mat\",\"full_name\":\"Condensed Matter\"},\"categories\":[{\"name\":\"cond-mat\",\"full_name\":\"Condensed Matter\"},{\"name\":\"chem-ph\",\"full_name\":null}],\"published_at\":\"1996-09-10T13:52:54+00:00\",\"updated_at\":\"1996-09-10T13:52:54+00:00\",\"comment?\":true,\"comment\":\"17 pages REVTEX 3.0, 2 postscript figures; hardcopy versions before May 96 are obsolete; accepted for publication in The Philosophical Magazine B\",\"journal?\":true,\"journal\":\"Phil. Mag. B 75, pp. 1-12 (1997)\",\"pdf?\":true,\"pdf_url\":\"http://arxiv.org/pdf/cond-mat/9609089v1\",\"doi?\":true,\"doi_url\":\"http://dx.doi.org/10.1080/13642819708205700\"}") }
+    end
+    context '1703.04834' do
+      subject { papers[3].to_json }
+
+      it { is_expected.to be_a String }
+      it { is_expected.to eq("{\"id\":\"1703.04834\",\"url\":\"http://arxiv.org/abs/1703.04834\",\"version\":1,\"revision?\":false,\"title\":\"A Quasi-Linear Time Algorithm Deciding Whether Weak Büchi Automata Reading Vectors of Reals Recognize Saturated Languages\",\"summary\":\"This work considers weak deterministic B\\\\\\\"uchi automata reading encodings of non-negative $d$-vectors of reals in a fixed base. A saturated language is a language which contains all encoding of elements belonging to a set of $d$-vectors of reals. A Real Vector Automaton is an automaton which recognizes a saturated language. It is explained how to decide in quasi-linear time whether a minimal weak deterministic B\\\\\\\"uchi automaton is a Real Vector Automaton. The problem is solved both for the two standard encodings of vectors of numbers: the sequential encoding and the parallel encoding. This algorithm runs in linear time for minimal weak B\\\\\\\"uchi automata accepting set of reals. Finally, the same problem is also solved for parallel encoding of automata reading vectors of relative reals.\",\"authors\":[{\"name\":\"Arthur Milchior\",\"affiliated?\":false,\"affiliations\":[]}],\"primary_category\":{\"name\":\"cs.FL\",\"full_name\":\"Formal Languages and Automata Theory\"},\"categories\":[{\"name\":\"cs.FL\",\"full_name\":\"Formal Languages and Automata Theory\"},{\"name\":\"03D05\",\"full_name\":null},{\"name\":\"F.1.1; F.4.1\",\"full_name\":null}],\"published_at\":\"2017-03-14T23:41:24+00:00\",\"updated_at\":\"2017-03-14T23:41:24+00:00\",\"comment?\":false,\"journal?\":false,\"pdf?\":true,\"pdf_url\":\"http://arxiv.org/pdf/1703.04834v1\",\"doi?\":false}") }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,7 @@ Coveralls.wear!
 $LOAD_PATH.unshift File.join __dir__, '..', 'lib'
 require 'bundler/setup'
 require 'arx'
+require 'json'
+require 'date'
 
 include Arx


### PR DESCRIPTION
- Adds serialization support through the following methods:
  - `to_h`: Serialize into a Ruby hash (with symbol keys). Accepts a boolean argument, representing whether or not to deep-serialize nested `Author` and `Category` objects (defaults to `false`).
  - `as_json`: Serialize into a Ruby hash which is also a valid JSON hash.
  - `to_json`: Serialize into a valid JSON string.
- Adds `ATTRIBUTES` constant for `Paper`, `Author` and `Category` entities, as a list of which attributes are available for the entity.