### PR TITLE
[patch:lib] Remove key-word arguments from Paper#id and Paper#url

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,11 @@ paper = Arx('1809.09415')
 
 paper.id
 #=> "1809.09415"
-paper.id(version: true)
+paper.id(true)
 #=> "1809.09415v1"
 paper.url
 #=> "http://arxiv.org/abs/1809.09415"
-paper.url(version: true)
+paper.url(true)
 #=> "http://arxiv.org/abs/1809.09415v1"
 paper.version
 #=> 1

--- a/lib/arx/entities/paper.rb
+++ b/lib/arx/entities/paper.rb
@@ -29,7 +29,7 @@ module Arx
     #   cond-mat/0211034
     # @param version [Boolean] Whether or not to include the paper's version.
     # @return [String] The paper's identifier.
-    def id(version: false)
+    def id(version = false)
       Cleaner.extract_id @id, version: version
     end
 
@@ -40,8 +40,8 @@ module Arx
     #   http://arxiv.org/abs/cond-mat/0211034
     # @param version [Boolean] Whether or not to include the paper's version.
     # @return [String] The paper's arXiv URL.
-    def url(version: false)
-      "http://arxiv.org/abs/#{id version: version}"
+    def url(version = false)
+      "http://arxiv.org/abs/#{id version}"
     end
 
     # The version of the paper.

--- a/spec/arx/entities/paper_spec.rb
+++ b/spec/arx/entities/paper_spec.rb
@@ -24,16 +24,16 @@ describe Paper do
     end
     context 'with version' do
       context 'cond-mat/9609089' do
-        it { expect(papers[0].id version: true).to eq 'cond-mat/9609089v1' }
+        it { expect(papers[0].id true).to eq 'cond-mat/9609089v1' }
       end
       context '1105.5379' do
-        it { expect(papers[1].id version: true).to eq '1105.5379v1' }
+        it { expect(papers[1].id true).to eq '1105.5379v1' }
       end
       context '1710.02185' do
-        it { expect(papers[2].id version: true).to eq '1710.02185v3' }
+        it { expect(papers[2].id true).to eq '1710.02185v3' }
       end
       context '1703.04834' do
-        it { expect(papers[3].id version: true).to eq '1703.04834v1' }
+        it { expect(papers[3].id true).to eq '1703.04834v1' }
       end
     end
   end
@@ -54,16 +54,16 @@ describe Paper do
     end
     context 'with version' do
       context 'cond-mat/9609089' do
-        it { expect(papers[0].url version: true).to eq 'http://arxiv.org/abs/cond-mat/9609089v1' }
+        it { expect(papers[0].url true).to eq 'http://arxiv.org/abs/cond-mat/9609089v1' }
       end
       context '1105.5379' do
-        it { expect(papers[1].url version: true).to eq 'http://arxiv.org/abs/1105.5379v1' }
+        it { expect(papers[1].url true).to eq 'http://arxiv.org/abs/1105.5379v1' }
       end
       context '1710.02185' do
-        it { expect(papers[2].url version: true).to eq 'http://arxiv.org/abs/1710.02185v3' }
+        it { expect(papers[2].url true).to eq 'http://arxiv.org/abs/1710.02185v3' }
       end
       context '1703.04834' do
-        it { expect(papers[3].url version: true).to eq 'http://arxiv.org/abs/1703.04834v1' }
+        it { expect(papers[3].url true).to eq 'http://arxiv.org/abs/1703.04834v1' }
       end
     end
   end


### PR DESCRIPTION
- Remove key-word arguments from `Paper#id` and `Paper#url`.
  > Previously, `Paper#id` and `Paper#url` accepted a `version` key-word argument, which was a boolean variable indicating whether or not to include the version number in the ID or URL. 
  > 
  > This has now been changed to a regular argument, which still defaults to `false`.
  > ```ruby
  > paper = Arx.get('cond-mat/9609089')
  >
  > # Old (no longer works)
  > paper.id(version: true)
  > paper.url(version: true)
  > 
  > # New
  > paper.id(true) #=> "cond-mat/9609089v1"
  > paper.url(true) #=> "http://arxiv.org/abs/cond-mat/9609089v1"