### PR TITLE
[patch:gem] De-version bundler requirement in arx.gemspec

### DIFF
--- a/arx.gemspec
+++ b/arx.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri', '~> 1.10'
   spec.add_runtime_dependency 'nokogiri-happymapper', '~> 0.8'
 
-  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'thor', '~> 0.20.3'
   spec.add_development_dependency 'rspec', '~> 3.7'


### PR DESCRIPTION
- Remove version specifier for `bundler` gem in gemspec.