### PR TITLE
[feature:lib] Allow searching by last_updated_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Although [Scholastica](https://github.com/scholastica) offer a great [Ruby gem](
 ## Features
 
 - Ruby classes `Arx::Paper`, `Arx::Author` and `Arx::Category` that wrap the resulting Atom XML query result from the search API.
-- Supports querying by a paper's ID, title, author(s), abstract, subject category, comment, journal reference, or report number.
+- Supports querying by a paper's ID, title, author(s), abstract, subject category, comment, journal reference, report number or last updated date.
 - Provides a small DSL for writing queries.
 - Supports searching fields by exact match.
 
@@ -133,14 +133,15 @@ The arXiv search API supports searches for the following paper metadata fields:
 
 ```ruby
 FIELDS = {
-  title: 'ti',     # Title
-  author: 'au',    # Author
-  abstract: 'abs', # Abstract
-  comment: 'co',   # Comment
-  journal: 'jr',   # Journal reference
-  category: 'cat', # Subject category
-  report: 'rn',    # Report number
-  all: 'all'       # All (of the above)
+  title: 'ti',                          # Title
+  author: 'au',                         # Author
+  abstract: 'abs',                      # Abstract
+  comment: 'co',                        # Comment
+  journal: 'jr',                        # Journal reference
+  category: 'cat',                      # Subject category
+  report: 'rn',                         # Report number
+  last_updated_date: 'lastUpdatedDate', # Last updated date
+  all: 'all'                            # All (of the above)
 }
 ```
 

--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -27,14 +27,15 @@ module Arx
     # @see https://arxiv.org/help/prep arXiv metadata fields
     # @see https://arxiv.org/help/api/user-manual#query_details arXiv user manual (query details)
     FIELDS = {
-      title: 'ti',     # Title
-      author: 'au',    # Author
-      abstract: 'abs', # Abstract
-      comment: 'co',   # Comment
-      journal: 'jr',   # Journal reference
-      category: 'cat', # Subject category
-      report: 'rn',    # Report number
-      all: 'all'       # All (of the above)
+      title: 'ti',                          # Title
+      author: 'au',                         # Author
+      abstract: 'abs',                      # Abstract
+      comment: 'co',                        # Comment
+      journal: 'jr',                        # Journal reference
+      category: 'cat',                      # Subject category
+      report: 'rn',                         # Report number
+      last_updated_date: 'lastUpdatedDate', # Last updated date
+      all: 'all'                            # All (of the above)
     }
 
     # Supported criteria for the +sortBy+ parameter.
@@ -147,6 +148,13 @@ module Arx
     # Search for papers by {https://arxiv.org/help/prep#report report number}.
     #
     # @param values [Array<String>] Report number(s) of papers to search for.
+    # @param connective [Symbol] The logical connective to use (see {CONNECTIVES}). Only applies if there are multiple values.
+    # @return [self]
+
+    # @!method last_updated_date(*values, connective: :and)
+    # Search for papers by lastUpdatedDate.
+    #
+    # @param values [Array<String>] lastUpdatedDate (String or range) of papers to search for.
     # @param connective [Symbol] The logical connective to use (see {CONNECTIVES}). Only applies if there are multiple values.
     # @return [self]
 


### PR DESCRIPTION
### Checklist
- [x] All old and new tests pass (ran `bundle exec rspec spec` in the root directory).
- [x] Read the [contribution guidelines](/CONTRIBUTING.md).
- [x] Updated documentation (if necessary).

### Reason (or issue)
ArXiv allows to include `lastUpdatedDate` in the `search_query` param. 

### Description
This PR adds support for using _lastUpdatedDate_ in the search API