### PR TITLE
[patch:lib] Change incorrect lastUpdated to lastUpdatedDate

### DIFF
--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -42,7 +42,7 @@ module Arx
     # Supported criteria for the +sortBy+ parameter.
     SORT_BY = {
       relevance: 'relevance',
-      last_updated: 'lastUpdated',
+      last_updated: 'lastUpdatedDate',
       date_submitted: 'submittedDate'
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Arx!
Before you submit your pull request, please make sure to check the following boxes.
-->

### Checklist
- [x] All old and new tests pass (ran `bundle exec rspec spec` in the root directory).
- [x] Read the [contribution guidelines](/CONTRIBUTING.md).
- [x] Updated documentation (if necessary).

### Reason (or issue)

The specified field `lastUpdated` does not match with the expected field `lastUpdatedDate` on the arXiv API.