### PR TITLE
[feature:lib] Add submitted_at for submission date querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ FIELDS = {
   category: 'cat',                      # Subject category
   report: 'rn',                         # Report number
   last_updated_date: 'lastUpdatedDate', # Last updated date
+  submitted_date: 'submittedDate',      # Submission date
   all: 'all'                            # All (of the above)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Although [Scholastica](https://github.com/scholastica) offer a great [Ruby gem](
   ```ruby
   require 'arx'
 
-  papers = Arx(sort_by: :date_submitted) do |query|
+  papers = Arx(sort_by: :submitted_at) do |query|
     query.category('cs.FL')
     query.title('Buchi Automata').and_not.author('Tomáš Babiak')
   end
@@ -92,13 +92,13 @@ The `Arx::Query` class provides a small DSL for writing these query strings.
 
 The order in which search results are returned can be modified through the `sort_by` and `sort_order` keyword arguments (in the `Arx::Query` initializer):
 
-- `sort_by` accepts the symbols: `:relevance`, `:last_updated` or `:date_submitted`
+- `sort_by` accepts the symbols: `:relevance`, `:updated_at` or `:submitted_at`
 
 - `sort_order` accepts the symbols: `:ascending` or `:descending`
 
 ```ruby
 # Sort by submission date in ascending order (earliest first)
-Arx::Query.new(sort_by: :date_submitted, sort_order: :ascending)
+Arx::Query.new(sort_by: :submitted_at, sort_order: :ascending)
 #=> sortBy=submittedDate&sortOrder=ascending
 ```
 
@@ -153,16 +153,16 @@ The arXiv search API supports searches for the following paper metadata fields:
 
 ```ruby
 FIELDS = {
-  title: 'ti',                          # Title
-  author: 'au',                         # Author
-  abstract: 'abs',                      # Abstract
-  comment: 'co',                        # Comment
-  journal: 'jr',                        # Journal reference
-  category: 'cat',                      # Subject category
-  report: 'rn',                         # Report number
-  last_updated_date: 'lastUpdatedDate', # Last updated date
-  submitted_date: 'submittedDate',      # Submission date
-  all: 'all'                            # All (of the above)
+  title: 'ti',                   # Title
+  author: 'au',                  # Author
+  abstract: 'abs',               # Abstract
+  comment: 'co',                 # Comment
+  journal: 'jr',                 # Journal reference
+  category: 'cat',               # Subject category
+  report: 'rn',                  # Report number
+  updated_at: 'lastUpdatedDate', # Last updated date
+  submitted_at: 'submittedDate', # Submission date
+  all: 'all'                     # All (of the above)
 }
 ```
 
@@ -278,7 +278,7 @@ Calling the `Arx()` method with a block allows for the construction and executio
 
 ```ruby
 # Papers in the cs.FL category whose title contains "Buchi Automata", not authored by Tomáš Babiak
-results = Arx(sort_by: :date_submitted) do |query|
+results = Arx(sort_by: :submitted_at) do |query|
   query.category('cs.FL')
   query.title('Buchi Automata').and_not.author('Tomáš Babiak')
 end
@@ -294,7 +294,7 @@ The `Arx()` method accepts a predefined `Arx::Query` object through the `query` 
 
 ```ruby
 # Papers in the cs.FL category whose title contains "Buchi Automata", not authored by Tomáš Babiak
-q = Arx::Query.new(sort_by: :date_submitted)
+q = Arx::Query.new(sort_by: :submitted_at)
 q.category('cs.FL')
 q.title('Buchi Automata').and_not.author('Tomáš Babiak')
 

--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -37,6 +37,7 @@ module Arx
       category: 'cat',                      # Subject category
       report: 'rn',                         # Report number
       last_updated_date: 'lastUpdatedDate', # Last updated date
+      submitted_date: 'submittedDate',      # Submission date
       all: 'all'                            # All (of the above)
     }
 
@@ -161,7 +162,14 @@ module Arx
     # @!method last_updated_date(*values, connective: :and)
     # Search for papers by lastUpdatedDate.
     #
-    # @param values [Array<String>] lastUpdatedDate (String or range) of papers to search for.
+    # @param values [Array<String>] lastUpdatedDate (string or range) of papers to search for.
+    # @param connective [Symbol] The logical connective to use (see {CONNECTIVES}). Only applies if there are multiple values.
+    # @return [self]
+
+    # @!method submitted_date(*values, connective: :and)
+    # Search for papers by submittedDate.
+    #
+    # @param values [Array<String>] submittedDate (string or range) of papers to search for.
     # @param connective [Symbol] The logical connective to use (see {CONNECTIVES}). Only applies if there are multiple values.
     # @return [self]
 
@@ -174,7 +182,8 @@ module Arx
     # @return [self]
 
     FIELDS.each do |name, field|
-      define_method(name) do |*values, exact: true, connective: :and|
+      exact = ![:last_updated_date, :submitted_date].include?(name)
+      define_method(name) do |*values, exact: exact, connective: :and|
         return if values.empty?
 
         values.flatten!

--- a/lib/arx/query/query.rb
+++ b/lib/arx/query/query.rb
@@ -29,23 +29,23 @@ module Arx
     # @see https://arxiv.org/help/prep arXiv metadata fields
     # @see https://arxiv.org/help/api/user-manual#query_details arXiv user manual (query details)
     FIELDS = {
-      title: 'ti',                          # Title
-      author: 'au',                         # Author
-      abstract: 'abs',                      # Abstract
-      comment: 'co',                        # Comment
-      journal: 'jr',                        # Journal reference
-      category: 'cat',                      # Subject category
-      report: 'rn',                         # Report number
-      last_updated_date: 'lastUpdatedDate', # Last updated date
-      submitted_date: 'submittedDate',      # Submission date
-      all: 'all'                            # All (of the above)
+      title: 'ti',                   # Title
+      author: 'au',                  # Author
+      abstract: 'abs',               # Abstract
+      comment: 'co',                 # Comment
+      journal: 'jr',                 # Journal reference
+      category: 'cat',               # Subject category
+      report: 'rn',                  # Report number
+      updated_at: 'lastUpdatedDate', # Last updated date
+      submitted_at: 'submittedDate', # Submission date
+      all: 'all'                     # All (of the above)
     }
 
     # Supported criteria for the +sortBy+ parameter.
     SORT_BY = {
       relevance: 'relevance',
-      last_updated: 'lastUpdatedDate',
-      date_submitted: 'submittedDate'
+      updated_at: 'lastUpdatedDate',
+      submitted_at: 'submittedDate'
     }
 
     # Supported criteria for the +sortOrder+ parameter.
@@ -159,14 +159,14 @@ module Arx
     # @param connective [Symbol] The logical connective to use (see {CONNECTIVES}). Only applies if there are multiple values.
     # @return [self]
 
-    # @!method last_updated_date(*values, connective: :and)
+    # @!method updated_at(*values, connective: :and)
     # Search for papers by lastUpdatedDate.
     #
     # @param values [Array<String>] lastUpdatedDate (string or range) of papers to search for.
     # @param connective [Symbol] The logical connective to use (see {CONNECTIVES}). Only applies if there are multiple values.
     # @return [self]
 
-    # @!method submitted_date(*values, connective: :and)
+    # @!method submitted_at(*values, connective: :and)
     # Search for papers by submittedDate.
     #
     # @param values [Array<String>] submittedDate (string or range) of papers to search for.
@@ -182,8 +182,8 @@ module Arx
     # @return [self]
 
     FIELDS.each do |name, field|
-      exact = ![:last_updated_date, :submitted_date].include?(name)
-      define_method(name) do |*values, exact: exact, connective: :and|
+      _exact = ![:updated_at, :submitted_at].include?(name)
+      define_method(name) do |*values, exact: _exact, connective: :and|
         return if values.empty?
 
         values.flatten!

--- a/spec/arx/query/query_spec.rb
+++ b/spec/arx/query/query_spec.rb
@@ -111,21 +111,21 @@ describe Query do
       let(:query) { Query.new }
 
       context 'without a query string' do
-        it { expect(query.send(field, 'cs.AI').to_s).to eq "#{default_arguments}&search_query=#{Query::FIELDS[field]}:%22cs.AI%22" }
+        it { expect(query.send(field, 'cs.AI', exact: true).to_s).to eq "#{default_arguments}&search_query=#{Query::FIELDS[field]}:%22cs.AI%22" }
       end
       context 'without a prior connective' do
-        it { expect(query.title('test').send(field, 'cs.AI').to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+AND+#{Query::FIELDS[field]}:%22cs.AI%22" }
+        it { expect(query.title('test').send(field, 'cs.AI', exact: true).to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+AND+#{Query::FIELDS[field]}:%22cs.AI%22" }
       end
       context 'with a prior connective' do
         Query::CONNECTIVES.keys.each do |connective|
-          it { expect(query.title('test').send(connective).send(field, 'cs.AI').to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+#{Query::CONNECTIVES[connective]}+#{Query::FIELDS[field]}:%22cs.AI%22" }
+          it { expect(query.title('test').send(connective).send(field, 'cs.AI', exact: true).to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+#{Query::CONNECTIVES[connective]}+#{Query::FIELDS[field]}:%22cs.AI%22" }
         end
       end
       context 'exact: false' do
         it { expect(query.send(field, 'cs.AI', exact: false).to_s).to eq "#{default_arguments}&search_query=#{Query::FIELDS[field]}:cs.AI" }
       end
       context 'with multiple values' do
-        it { expect(query.title('test').send(field, 'cs.AI', 'cs.LG').to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+AND+%28#{Query::FIELDS[field]}:%22cs.AI%22+AND+#{Query::FIELDS[field]}:%22cs.LG%22%29" }
+        it { expect(query.title('test').send(field, 'cs.AI', 'cs.LG', exact: true).to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+AND+%28#{Query::FIELDS[field]}:%22cs.AI%22+AND+#{Query::FIELDS[field]}:%22cs.LG%22%29" }
 
         context 'exact: false' do
           it { expect(query.title('test').send(field, 'cs.AI', 'cs.LG', exact: false).to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+AND+%28#{Query::FIELDS[field]}:cs.AI+AND+#{Query::FIELDS[field]}:cs.LG%29" }
@@ -133,7 +133,7 @@ describe Query do
 
         Query::CONNECTIVES.keys.each do |connective|
           context "connective: #{connective}" do
-            it { expect(query.title('test').send(field, 'cs.AI', 'cs.LG', connective: connective).to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+AND+%28#{Query::FIELDS[field]}:%22cs.AI%22+#{Query::CONNECTIVES[connective]}+#{Query::FIELDS[field]}:%22cs.LG%22%29" }
+            it { expect(query.title('test').send(field, 'cs.AI', 'cs.LG', connective: connective, exact: true).to_s).to eq "#{default_arguments}&search_query=ti:%22test%22+AND+%28#{Query::FIELDS[field]}:%22cs.AI%22+#{Query::CONNECTIVES[connective]}+#{Query::FIELDS[field]}:%22cs.LG%22%29" }
           end
         end
       end

--- a/spec/arx/query/query_spec.rb
+++ b/spec/arx/query/query_spec.rb
@@ -81,7 +81,7 @@ describe Query do
       end
     end
     context 'with IDs and key-word arguments' do
-      it { expect(subject.new('1105.5379', 'cond-mat/9609089', sort_by: :date_submitted, sort_order: :ascending).to_s).to eq 'sortBy=submittedDate&sortOrder=ascending&start=0&max_results=10&id_list=1105.5379,cond-mat/9609089' }
+      it { expect(subject.new('1105.5379', 'cond-mat/9609089', sort_by: :submitted_at, sort_order: :ascending).to_s).to eq 'sortBy=submittedDate&sortOrder=ascending&start=0&max_results=10&id_list=1105.5379,cond-mat/9609089' }
     end
   end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Arx!
Before you submit your pull request, please make sure to check the following boxes.
-->

### Checklist
- [x] All old and new tests pass (ran `bundle exec rspec spec` in the root directory).
- [x] Read the [contribution guidelines](/CONTRIBUTING.md).
- [x] Updated documentation (if necessary).

### Reason (or issue)

After reading into how it is possible to query using `lastUpdatedDate` in #93, it appears that it is also possible to do the same with `submittedDate`, so this PR implements that.

Note that instead of adding `Arx::Query#submitted_date`, we define it as `Arx::Query#submitted_at`. `Arx::Query#last_updated_date` is also changed to `Arx::Query#updated_at`. This is done in order to match the naming pattern of [`Arx::Paper#updated_at`](https://github.com/eonu/arx/blob/3d093658579fb2d99b92f0feedb2aa790a22e2c8/lib/arx/entities/paper.rb#L62) and [`Arx::Paper#published_at`](https://github.com/eonu/arx/blob/3d093658579fb2d99b92f0feedb2aa790a22e2c8/lib/arx/entities/paper.rb#L68).

This design decision is inspired by [`ActiveRecord::Timestamp`](https://api.rubyonrails.org/classes/ActiveRecord/Timestamp.html)'s `created_at` and `updated_at`.

The same changes are made to the `last_updated` and `date_submitted` [sort-by criteria](https://github.com/eonu/arx/blob/3d093658579fb2d99b92f0feedb2aa790a22e2c8/lib/arx/query/query.rb#L43).