### PR TITLE
[patch:docs] Fix typo in Arx::Category#to_s docstring

### DIFF
--- a/lib/arx/entities/category.rb
+++ b/lib/arx/entities/category.rb
@@ -57,7 +57,7 @@ module Arx
       end
     end
 
-    # A string representation of the {Author} object.
+    # A string representation of the {Category} object.
     #
     # @return [String]
     def to_s


### PR DESCRIPTION
- Fix typo in `Arx::Category#to_s` docstring.